### PR TITLE
Add explicit snapshots to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1232,7 +1232,7 @@ Most but not all `abstract-level` implementations support snapshots. They can be
 
 #### 1. Implementation does not support snapshots
 
-As indicated by `db.supports.snapshots` being false. In this case, operations read from the latest version of the database. This most noticeably affects iterators:
+As indicated by `db.supports.snapshots` being false. In this case, operations read from the latest version of the database. This most notably affects iterators:
 
 ```js
 await db.put('example', 'a')

--- a/README.md
+++ b/README.md
@@ -697,9 +697,9 @@ console.log(foo.path(true)) // ['example', 'nested', 'foo']
 
 ### `snapshot`
 
-#### `snapshot.close([callback])`
+#### `snapshot.close()`
 
-Free up underlying resources. Be sure to call this when the snapshot is no longer needed, because snapshots may cause the database to temporarily pause internal storage optimizations. The `callback` function will be called with no arguments. If no callback is provided, a promise is returned. Closing the snapshot is an idempotent operation, such that calling `snapshot.close()` more than once is allowed and makes no difference.
+Free up underlying resources. Be sure to call this when the snapshot is no longer needed, because snapshots may cause the database to temporarily pause internal storage optimizations. Returns a promise. Closing the snapshot is an idempotent operation, such that calling `snapshot.close()` more than once is allowed and makes no difference.
 
 After `snapshot.close()` has been called, no further operations are allowed. For example, `db.get(key, { snapshot })` will yield an error with code [`LEVEL_SNAPSHOT_NOT_OPEN`](#errors). Any unclosed iterators (that use this snapshot) will be closed by `snapshot.close()` and can then no longer be used.
 
@@ -1754,11 +1754,11 @@ The default `_close()` returns a resolved promise. Overriding is optional.
 
 The first argument to this constructor must be an instance of the relevant `AbstractLevel` implementation. The constructor will set `snapshot.db` which ensures that `db` will not be garbage collected in case there are no other references to it.
 
-#### `snapshot._close(callback)`
+#### `snapshot._close()`
 
-Free up underlying resources. This method is guaranteed to only be called once. Once closing is done, call `callback` without any arguments. It is not allowed to yield an error.
+Free up underlying resources. This method is guaranteed to only be called once. Must return a promise.
 
-The default `_close()` invokes `callback` on a next tick. Overriding is optional.
+The default `_close()` returns a resolved promise. Overriding is optional.
 
 ## Test Suite
 

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ console.log(nested.prefixKey('a', 'utf8', true)) // '!nested!a'
 
 ### `snapshot = db.snapshot()`
 
-**This is an experimental API and not widely supported at the time of writing.**
+**This is an experimental API and not widely supported at the time of writing ([Level/community#118](https://github.com/Level/community/issues/118)).**
 
 Create an explicit [snapshot](#snapshot). Throws a [`LEVEL_NOT_SUPPORTED`](#errors) error if `db.supports.explicitSnapshots` is not true. For details, see [Reading From Snapshots](#reading-from-snapshots).
 


### PR DESCRIPTION
This is a documentation-only PR, acting as an RFC. I opted for a token-based approach (as suggested by Rod Vagg in https://github.com/Level/community/issues/45) instead of a dedicated snapshot API surface (as suggested by @juliangruber in https://github.com/Level/community/issues/47). Main reasons for not choosing the latter:

- It would be a third API surface. We have the main database API surface which is roughly equal to that of a sublevel, and would now add another API surface which only has read methods, e.g. `db.snapshot().get()`. If you could pass around a snapshot as if it was a regular database (like you can with sublevels) then I'd be cool with it. But for that to happen, we'd have to implement write methods and thus transactions as well, which I consider to be out of scope although transactions are in fact a use case of snapshots.
- It would have a higher complexity once you factor in sublevels. I.e. to make `db.sublevel().snapshot().get(key)` read from the snapshot but also prefix the given key. By instead doing `db.sublevel().get(key, { snapshot })`, the sublevel can just forward that snapshot option to its parent database.
- Furthermore, with the token-based approach, you can pass a snapshot to multiple sublevels, which cleanly solves the main use case of retrieving data from an index (see [example](https://github.com/Level/abstract-level/tree/explicit-snapshots#3-implementation-supports-explicit-snapshots)).

I renamed the existing snapshot mechanism to "implicit snapshots" and attempted to clarify the behavior of those as well.

Several related issues can be closed, because this PR:

- Includes (a more complete write-up than) https://github.com/Level/classic-level/pull/40.
- Mentions https://github.com/Level/leveldown/issues/796 (which should be moved rather than closed).
- Answers https://github.com/Level/classic-level/issues/28.
- Solves the main use case as described in https://github.com/Level/leveldown/issues/486.
- Effectively completes https://github.com/Level/awesome/issues/19.