### PR TITLE
Add hooks and deprecate `batch`, `put` & `del` events

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@
     - [`iterator._close(callback)`](#iterator_closecallback)
   - [`keyIterator = AbstractKeyIterator(db, options)`](#keyiterator--abstractkeyiteratordb-options)
   - [`valueIterator = AbstractValueIterator(db, options)`](#valueiterator--abstractvalueiteratordb-options)
-  - [`chainedBatch = AbstractChainedBatch(db)`](#chainedbatch--abstractchainedbatchdb)
+  - [`chainedBatch = AbstractChainedBatch(db, options)`](#chainedbatch--abstractchainedbatchdb-options)
+    - [`chainedBatch._add(op)`](#chainedbatch_addop)
     - [`chainedBatch._put(key, value, options)`](#chainedbatch_putkey-value-options)
     - [`chainedBatch._del(key, options)`](#chainedbatch_delkey-options)
     - [`chainedBatch._clear()`](#chainedbatch_clear)
@@ -1636,25 +1637,31 @@ The `options` argument must be the original `options` object that was passed to 
 
 A value iterator has the same interface and constructor arguments as `AbstractIterator` except that it must yields values instead of entries. For further details, see `keyIterator` above.
 
-### `chainedBatch = AbstractChainedBatch(db)`
+### `chainedBatch = AbstractChainedBatch(db, options)`
 
 The first argument to this constructor must be an instance of the relevant `AbstractLevel` implementation. The constructor will set `chainedBatch.db` which is used (among other things) to access encodings and ensures that `db` will not be garbage collected in case there are no other references to it.
 
+There are two ways to implement a chained batch. If `options.add` is true, only `_add()` will be called. If `options.add` is false or not provided, only `_put()` and `_del()` will be called.
+
+#### `chainedBatch._add(op)`
+
+Add a `put` or `del` operation. The `op` object will always have the following properties: `type`, `key`, `keyEncoding` and (if `type` is `'put'`) `value` and `valueEncoding`.
+
 #### `chainedBatch._put(key, value, options)`
 
-Queue a `put` operation on this batch. The `options` object will always have the following properties: `keyEncoding` and `valueEncoding`.
+Add a `put` operation. The `options` object will always have the following properties: `keyEncoding` and `valueEncoding`.
 
 #### `chainedBatch._del(key, options)`
 
-Queue a `del` operation on this batch. The `options` object will always have the following properties: `keyEncoding`.
+Add a `del` operation. The `options` object will always have the following properties: `keyEncoding`.
 
 #### `chainedBatch._clear()`
 
-Clear all queued operations on this batch.
+Remove all operations from this batch.
 
 #### `chainedBatch._write(options, callback)`
 
-The default `_write` method uses `db._batch`. If the `_write` method is overridden it must atomically commit the queued operations. There are no default options but `options` will always be an object. If committing fails, call the `callback` function with an error. Otherwise call `callback` without any arguments. The `_write()` method will not be called if the chained batch has zero queued operations.
+The default `_write` method uses `db._batch`. If the `_write` method is overridden it must atomically commit the operations. There are no default options but `options` will always be an object. If committing fails, call the `callback` function with an error. Otherwise call `callback` without any arguments. The `_write()` method will not be called if the chained batch contains zero operations.
 
 #### `chainedBatch._close(callback)`
 

--- a/README.md
+++ b/README.md
@@ -979,7 +979,7 @@ Emitted when database is opening. Receives 0 arguments:
 
 ```js
 db.once('opening', function () {
-  console.log('Opening..')
+  console.log('Opening...')
 })
 ```
 
@@ -1030,10 +1030,10 @@ As an example, given a sublevel created with `users = db.sublevel('users', { val
 
 ```js
 [{
-  type: 'put'
+  type: 'put',
   key: 'isa',
   value: { score: 10 },
-  keyEncoding: users.keyEncoding('utf8')
+  keyEncoding: users.keyEncoding('utf8'),
   valueEncoding: users.valueEncoding('json'),
   encodedKey: 'isa', // No change (was already utf8)
   encodedValue: '{"score":10}', // JSON-encoded
@@ -1044,10 +1044,10 @@ Because sublevels encode and then forward operations to their parent database, a
 
 ```js
 [{
-  type: 'put'
+  type: 'put',
   key: '!users!isa', // Prefixed
   value: '{"score":10}', // No change
-  keyEncoding: db.keyEncoding('utf8')
+  keyEncoding: db.keyEncoding('utf8'),
   valueEncoding: db.valueEncoding('utf8'),
   encodedKey: '!users!isa',
   encodedValue: '{"score":10}'
@@ -1066,7 +1066,7 @@ We'll get:
 
 ```js
 [{
-  type: 'del'
+  type: 'del',
   key: '!users!isa', // Prefixed
   keyEncoding: db.keyEncoding('utf8'),
   encodedKey: '!users!isa'

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -43,7 +43,7 @@ const colorIndex = indexes.sublevel('colors')
 
 It will now forward its operations to `indexes`, which in turn forwards them to `db`. At each step, hooks and events are available to transform and react to data from a different perspective. Which comes at a (typically small) performance cost that increases with further nested sublevels. This decreased performance is the **first breaking change** and mainly affects sublevels nested at a depth of more than 2.
 
-To optionally negate it, a new feature has been added to `db.sublevel(name)`: it now accepts an array `name` too. If the `indexes` sublevel is only used to organize keys and not directly interfaced with, operations on `colorIndex` can be made faster by skipping `indexes`:
+To optionally negate it, a new feature has been added to `db.sublevel(name)`: it now also accepts a `name` that is an array. If the `indexes` sublevel is only used to organize keys and not directly interfaced with, operations on `colorIndex` can be made faster by skipping `indexes`:
 
 ```js
 const colorIndex = db.sublevel(['idx', 'colors'])

--- a/abstract-chained-batch.js
+++ b/abstract-chained-batch.js
@@ -251,7 +251,6 @@ class AbstractChainedBatch {
 
   _del (key, options) {}
 
-  // TODO: docs
   _add (op) {}
 
   clear () {

--- a/abstract-chained-batch.js
+++ b/abstract-chained-batch.js
@@ -2,25 +2,61 @@
 
 const { fromCallback } = require('catering')
 const ModuleError = require('module-error')
-const { getCallback, getOptions } = require('./lib/common')
+const { getCallback, getOptions, emptyOptions } = require('./lib/common')
+const { PrewriteBatch } = require('./lib/prewrite-batch')
 
 const kPromise = Symbol('promise')
 const kStatus = Symbol('status')
-const kOperations = Symbol('operations')
+const kPublicOperations = Symbol('publicOperations')
+const kLegacyOperations = Symbol('legacyOperations')
+const kPrivateOperations = Symbol('privateOperations')
 const kFinishClose = Symbol('finishClose')
 const kCloseCallbacks = Symbol('closeCallbacks')
+const kLength = Symbol('length')
+const kPrewriteRun = Symbol('prewriteRun')
+const kPrewriteBatch = Symbol('prewriteBatch')
+const kPrewriteData = Symbol('prewriteData')
+const kAddMode = Symbol('addMode')
 
 class AbstractChainedBatch {
-  constructor (db) {
+  constructor (db, options) {
     if (typeof db !== 'object' || db === null) {
       const hint = db === null ? 'null' : typeof db
       throw new TypeError(`The first argument must be an abstract-level database, received ${hint}`)
     }
 
-    this[kOperations] = []
+    const enableWriteEvent = db.listenerCount('write') > 0
+    const enablePrewriteHook = !db.hooks.prewrite.noop
+
+    // Operations for write event. We can skip populating this array (and cloning of
+    // operations, which is the expensive part) if there are 0 write event listeners.
+    this[kPublicOperations] = enableWriteEvent ? [] : null
+
+    // Operations for legacy batch event. If user opted-in to write event or prewrite
+    // hook, skip legacy batch event. We can't skip the batch event based on listener
+    // count, because a listener may be added between put() or del() and write().
+    this[kLegacyOperations] = enableWriteEvent || enablePrewriteHook ? null : []
+
+    this[kLength] = 0
     this[kCloseCallbacks] = []
     this[kStatus] = 'open'
     this[kFinishClose] = this[kFinishClose].bind(this)
+    this[kAddMode] = getOptions(options, emptyOptions).add === true
+
+    if (enablePrewriteHook) {
+      // Use separate arrays to collect operations added by hook functions, because
+      // we wait to apply those until write(). Store these arrays in PrewriteData which
+      // exists to separate internal data from the public PrewriteBatch interface.
+      const data = new PrewriteData([], enableWriteEvent ? [] : null)
+
+      this[kPrewriteData] = data
+      this[kPrewriteBatch] = new PrewriteBatch(db, data[kPrivateOperations], data[kPublicOperations])
+      this[kPrewriteRun] = db.hooks.prewrite.run // TODO: document why, and test
+    } else {
+      this[kPrewriteData] = null
+      this[kPrewriteBatch] = null
+      this[kPrewriteRun] = null
+    }
 
     this.db = db
     this.db.attachResource(this)
@@ -28,85 +64,202 @@ class AbstractChainedBatch {
   }
 
   get length () {
-    return this[kOperations].length
+    if (this[kPrewriteData] !== null) {
+      return this[kLength] + this[kPrewriteData].length
+    } else {
+      return this[kLength]
+    }
   }
 
   put (key, value, options) {
-    if (this[kStatus] !== 'open') {
-      throw new ModuleError('Batch is not open: cannot call put() after write() or close()', {
-        code: 'LEVEL_BATCH_NOT_OPEN'
-      })
+    assertStatus(this)
+    options = getOptions(options, emptyOptions)
+
+    const delegated = options.sublevel != null
+    const db = delegated ? options.sublevel : this.db
+    const original = options
+    const keyError = db._checkKey(key)
+    const valueError = db._checkValue(value)
+
+    if (keyError != null) throw keyError
+    if (valueError != null) throw valueError
+
+    // Avoid spread operator because of https://bugs.chromium.org/p/chromium/issues/detail?id=1204540
+    const op = Object.assign({}, options, {
+      type: 'put',
+      key,
+      value,
+      keyEncoding: db.keyEncoding(options.keyEncoding),
+      valueEncoding: db.valueEncoding(options.valueEncoding)
+    })
+
+    if (this[kPrewriteRun] !== null) {
+      try {
+        // Note: we could have chosen to recurse here so that prewriteBatch.put() would
+        // call this.put(). But then operations added by hook functions would be inserted
+        // before rather than after user operations. Instead we process those operations
+        // lazily in write(). This does hurt the only performance benefit benefit of a
+        // chained batch though, which is that it avoids blocking the event loop with
+        // more than one operation at a time. On the other hand, if operations added by
+        // hook functions are adjacent (i.e. sorted) committing them should be faster.
+        this[kPrewriteRun](op, this[kPrewriteBatch])
+      } catch (err) {
+        throw new ModuleError('The prewrite hook failed on batch.put()', {
+          code: 'LEVEL_HOOK_ERROR',
+          cause: err
+        })
+      }
     }
 
-    const err = this.db._checkKey(key) || this.db._checkValue(value)
-    if (err) throw err
-
-    const db = options && options.sublevel != null ? options.sublevel : this.db
-    const original = options
-    const keyEncoding = db.keyEncoding(options && options.keyEncoding)
-    const valueEncoding = db.valueEncoding(options && options.valueEncoding)
+    // Encode data for private API
+    const keyEncoding = op.keyEncoding
+    const encodedKey = keyEncoding.encode(op.key)
     const keyFormat = keyEncoding.format
-
-    // Forward encoding options
-    options = { ...options, keyEncoding: keyFormat, valueEncoding: valueEncoding.format }
+    const prefixedKey = db.prefixKey(encodedKey, keyFormat)
+    const valueEncoding = op.valueEncoding
+    const encodedValue = valueEncoding.encode(op.value)
+    const valueFormat = valueEncoding.format
 
     // Prevent double prefixing
-    if (db !== this.db) {
-      options.sublevel = null
+    if (delegated) op.sublevel = null
+
+    if (this[kPublicOperations] !== null) {
+      // Clone op before we mutate it for the private API
+      const publicOperation = Object.assign({}, op)
+
+      if (delegated) {
+        // Ensure emitted data makes sense in the context of this db
+        publicOperation.key = prefixedKey
+        publicOperation.value = encodedValue
+        publicOperation.keyEncoding = this.db.keyEncoding(keyFormat)
+        publicOperation.valueEncoding = this.db.valueEncoding(valueFormat)
+        publicOperation.encodedKey = prefixedKey
+        publicOperation.encodedValue = encodedValue
+      } else {
+        publicOperation.encodedKey = encodedKey
+        publicOperation.encodedValue = encodedValue
+      }
+
+      this[kPublicOperations].push(publicOperation)
+    } else if (this[kLegacyOperations] !== null) {
+      const legacyOperation = Object.assign({}, original)
+
+      legacyOperation.type = 'put'
+      legacyOperation.key = key
+      legacyOperation.value = value
+
+      this[kLegacyOperations].push(legacyOperation)
     }
 
-    const mappedKey = db.prefixKey(keyEncoding.encode(key), keyFormat)
-    const mappedValue = valueEncoding.encode(value)
+    op.key = prefixedKey
+    op.value = encodedValue
+    op.keyEncoding = keyFormat
+    op.valueEncoding = valueFormat
 
-    this._put(mappedKey, mappedValue, options)
-    this[kOperations].push({ ...original, type: 'put', key, value })
+    if (this[kAddMode]) {
+      this._add(op)
+    } else {
+      // This "operation as options" trick avoids further cloning
+      this._put(prefixedKey, encodedValue, op)
+    }
 
+    // Increment only on success
+    this[kLength]++
     return this
   }
 
   _put (key, value, options) {}
 
   del (key, options) {
-    if (this[kStatus] !== 'open') {
-      throw new ModuleError('Batch is not open: cannot call del() after write() or close()', {
-        code: 'LEVEL_BATCH_NOT_OPEN'
-      })
+    assertStatus(this)
+    options = getOptions(options, emptyOptions)
+
+    const delegated = options.sublevel != null
+    const db = delegated ? options.sublevel : this.db
+    const original = options
+    const keyError = db._checkKey(key)
+
+    if (keyError != null) throw keyError
+
+    // Avoid spread operator because of https://bugs.chromium.org/p/chromium/issues/detail?id=1204540
+    const op = Object.assign({}, options, {
+      type: 'del',
+      key,
+      keyEncoding: db.keyEncoding(options.keyEncoding)
+    })
+
+    if (this[kPrewriteRun] !== null) {
+      try {
+        this[kPrewriteRun](op, this[kPrewriteBatch])
+      } catch (err) {
+        throw new ModuleError('The prewrite hook failed on batch.del()', {
+          code: 'LEVEL_HOOK_ERROR',
+          cause: err
+        })
+      }
     }
 
-    const err = this.db._checkKey(key)
-    if (err) throw err
-
-    const db = options && options.sublevel != null ? options.sublevel : this.db
-    const original = options
-    const keyEncoding = db.keyEncoding(options && options.keyEncoding)
+    // Encode data for private API
+    const keyEncoding = op.keyEncoding
+    const encodedKey = keyEncoding.encode(op.key)
     const keyFormat = keyEncoding.format
-
-    // Forward encoding options
-    options = { ...options, keyEncoding: keyFormat }
+    const prefixedKey = db.prefixKey(encodedKey, keyFormat)
 
     // Prevent double prefixing
-    if (db !== this.db) {
-      options.sublevel = null
+    if (delegated) op.sublevel = null
+
+    if (this[kPublicOperations] !== null) {
+      // Clone op before we mutate it for the private API
+      const publicOperation = Object.assign({}, op)
+
+      if (delegated) {
+        // Ensure emitted data makes sense in the context of this db
+        publicOperation.key = prefixedKey
+        publicOperation.keyEncoding = this.db.keyEncoding(keyFormat)
+        publicOperation.encodedKey = prefixedKey
+      } else {
+        publicOperation.encodedKey = encodedKey
+      }
+
+      this[kPublicOperations].push(publicOperation)
+    } else if (this[kLegacyOperations] !== null) {
+      const legacyOperation = Object.assign({}, original)
+
+      legacyOperation.type = 'del'
+      legacyOperation.key = key
+
+      this[kLegacyOperations].push(legacyOperation)
     }
 
-    this._del(db.prefixKey(keyEncoding.encode(key), keyFormat), options)
-    this[kOperations].push({ ...original, type: 'del', key })
+    op.key = prefixedKey
+    op.keyEncoding = keyFormat
 
+    if (this[kAddMode]) {
+      this._add(op)
+    } else {
+      // This "operation as options" trick avoids further cloning
+      this._del(prefixedKey, op)
+    }
+
+    // Increment only on success
+    this[kLength]++
     return this
   }
 
   _del (key, options) {}
 
+  // TODO: docs
+  _add (op) {}
+
   clear () {
-    if (this[kStatus] !== 'open') {
-      throw new ModuleError('Batch is not open: cannot call clear() after write() or close()', {
-        code: 'LEVEL_BATCH_NOT_OPEN'
-      })
-    }
-
+    assertStatus(this)
     this._clear()
-    this[kOperations] = []
 
+    if (this[kPublicOperations] !== null) this[kPublicOperations] = []
+    if (this[kLegacyOperations] !== null) this[kLegacyOperations] = []
+    if (this[kPrewriteData] !== null) this[kPrewriteData].clear()
+
+    this[kLength] = 0
     return this
   }
 
@@ -121,17 +274,51 @@ class AbstractChainedBatch {
       this.nextTick(callback, new ModuleError('Batch is not open: cannot call write() after write() or close()', {
         code: 'LEVEL_BATCH_NOT_OPEN'
       }))
-    } else if (this.length === 0) {
+    } else if (this[kLength] === 0) {
       this.close(callback)
     } else {
       this[kStatus] = 'writing'
+
+      // Process operations added by prewrite hook functions
+      if (this[kPrewriteData] !== null) {
+        const publicOperations = this[kPrewriteData][kPublicOperations]
+        const privateOperations = this[kPrewriteData][kPrivateOperations]
+        const length = this[kPrewriteData].length
+
+        for (let i = 0; i < length; i++) {
+          const op = privateOperations[i]
+
+          // We can _add(), _put() or _del() even though status is now 'writing' because
+          // status isn't exposed to the private API, so there's no difference in state
+          // from that perspective, unless an implementation overrides the public write()
+          // method at its own risk.
+          if (this[kAddMode]) {
+            this._add(op)
+          } else if (op.type === 'put') {
+            this._put(op.key, op.value, op)
+          } else {
+            this._del(op.key, op)
+          }
+        }
+
+        if (publicOperations !== null && length !== 0) {
+          this[kPublicOperations] = this[kPublicOperations].concat(publicOperations)
+        }
+      }
+
       this._write(options, (err) => {
         this[kStatus] = 'closing'
         this[kCloseCallbacks].push(() => callback(err))
 
         // Emit after setting 'closing' status, because event may trigger a
         // db close which in turn triggers (idempotently) closing this batch.
-        if (!err) this.db.emit('batch', this[kOperations])
+        if (!err) {
+          if (this[kPublicOperations] !== null) {
+            this.db.emit('write', this[kPublicOperations])
+          } else if (this[kLegacyOperations] !== null) {
+            this.db.emit('batch', this[kLegacyOperations])
+          }
+        }
 
         this._close(this[kFinishClose])
       })
@@ -175,6 +362,44 @@ class AbstractChainedBatch {
     for (const cb of callbacks) {
       cb()
     }
+  }
+}
+
+class PrewriteData {
+  constructor (privateOperations, publicOperations) {
+    this[kPrivateOperations] = privateOperations
+    this[kPublicOperations] = publicOperations
+  }
+
+  get length () {
+    return this[kPrivateOperations].length
+  }
+
+  clear () {
+    // Clear operation arrays if present.
+    for (const k of [kPublicOperations, kPrivateOperations]) {
+      const ops = this[k]
+
+      if (ops !== null) {
+        // Keep array alive because PrewriteBatch has a reference to it
+        ops.splice(0, ops.length)
+      }
+    }
+  }
+}
+
+function assertStatus (batch) {
+  if (batch[kStatus] !== 'open') {
+    throw new ModuleError('Batch is not open: cannot change operations after write() or close()', {
+      code: 'LEVEL_BATCH_NOT_OPEN'
+    })
+  }
+
+  // TODO (next major): enforce this regardless of hooks
+  if (batch[kPrewriteBatch] !== null && batch.db.status !== 'open') {
+    throw new ModuleError('Chained batch is not available until database is open', {
+      code: 'LEVEL_DATABASE_NOT_OPEN'
+    })
   }
 }
 

--- a/abstract-iterator.js
+++ b/abstract-iterator.js
@@ -260,7 +260,7 @@ class CommonIterator {
         options = { ...options, keyEncoding: keyFormat }
       }
 
-      const mapped = this.db.prefixKey(keyEncoding.encode(target), keyFormat)
+      const mapped = this.db.prefixKey(keyEncoding.encode(target), keyFormat, false)
       this._seek(mapped, options)
     }
   }

--- a/abstract-iterator.js
+++ b/abstract-iterator.js
@@ -2,7 +2,7 @@
 
 const { fromCallback } = require('catering')
 const ModuleError = require('module-error')
-const { getOptions, getCallback } = require('./lib/common')
+const { getOptions, getCallback, emptyOptions, noop, deprecate } = require('./lib/common')
 
 const kPromise = Symbol('promise')
 const kCallback = Symbol('callback')
@@ -24,10 +24,6 @@ const kKeys = Symbol('keys')
 const kValues = Symbol('values')
 const kLimit = Symbol('limit')
 const kCount = Symbol('count')
-
-const emptyOptions = Object.freeze({})
-const noop = () => {}
-let warnedEnd = false
 
 // This class is an internal utility for common functionality between AbstractIterator,
 // AbstractKeyIterator and AbstractValueIterator. It's not exported.
@@ -377,14 +373,7 @@ class AbstractIterator extends CommonIterator {
   }
 
   end (callback) {
-    if (!warnedEnd && typeof console !== 'undefined') {
-      warnedEnd = true
-      console.warn(new ModuleError(
-        'The iterator.end() method was renamed to close() and end() is an alias that will be removed in a future version',
-        { code: 'LEVEL_LEGACY' }
-      ))
-    }
-
+    deprecate('The iterator.end() method was renamed to close() and end() is an alias that will be removed in a future version')
     return this.close(callback)
   }
 }

--- a/abstract-level.js
+++ b/abstract-level.js
@@ -470,6 +470,8 @@ class AbstractLevel extends EventEmitter {
   put (key, value, options, callback) {
     if (!this.hooks.prewrite.noop) {
       // Forward to batch() which will run the hook
+      // Note: technically means that put() supports the sublevel option in this case,
+      // but it generally doesn't per documentation (which makes sense). Same for del().
       return this.batch([{ type: 'put', key, value }], options, callback)
     }
 
@@ -632,7 +634,7 @@ class AbstractLevel extends EventEmitter {
     callback = fromCallback(callback, kPromise)
     options = getOptions(options, this[kDefaultOptions].empty)
 
-    // TODO (not urgent): freeze prewrite hook
+    // TODO (not urgent): freeze prewrite hook and write event
     if (this[kStatus] === 'opening') {
       this.defer(() => this.batch(operations, options, callback))
       return callback[kPromise]
@@ -730,7 +732,6 @@ class AbstractLevel extends EventEmitter {
 
         if (delegated) {
           // Ensure emitted data makes sense in the context of this db
-          // TODO: write test (also for chained batch)
           publicOperation.key = prefixedKey
           publicOperation.keyEncoding = this.keyEncoding(keyFormat)
           publicOperation.encodedKey = prefixedKey

--- a/abstract-level.js
+++ b/abstract-level.js
@@ -502,7 +502,6 @@ class AbstractLevel extends EventEmitter {
     const original = options
 
     // Avoid Object.assign() for default options
-    // TODO: benchmark on classic-level
     // TODO: also apply this tweak to get() and getMany()
     if (options === this[kDefaultOptions].entry) {
       options = this[kDefaultOptions].entryFormat

--- a/abstract-level.js
+++ b/abstract-level.js
@@ -3,13 +3,17 @@
 const { supports } = require('level-supports')
 const { Transcoder } = require('level-transcoder')
 const { EventEmitter } = require('events')
-const { fromCallback } = require('catering')
+const { fromCallback, fromPromise } = require('catering')
 const ModuleError = require('module-error')
+const combineErrors = require('maybe-combine-errors')
 const { AbstractIterator } = require('./abstract-iterator')
 const { DefaultKeyIterator, DefaultValueIterator } = require('./lib/default-kv-iterator')
 const { DeferredIterator, DeferredKeyIterator, DeferredValueIterator } = require('./lib/deferred-iterator')
 const { DefaultChainedBatch } = require('./lib/default-chained-batch')
-const { getCallback, getOptions } = require('./lib/common')
+const { DatabaseHooks } = require('./lib/hooks')
+const { PrewriteBatch } = require('./lib/prewrite-batch')
+const { EventMonitor } = require('./lib/event-monitor')
+const { getCallback, getOptions, noop, emptyOptions } = require('./lib/common')
 const rangeOptions = require('./lib/range-options')
 
 const kPromise = Symbol('promise')
@@ -25,7 +29,7 @@ const kDefaultOptions = Symbol('defaultOptions')
 const kTranscoder = Symbol('transcoder')
 const kKeyEncoding = Symbol('keyEncoding')
 const kValueEncoding = Symbol('valueEncoding')
-const noop = () => {}
+const kEventMonitor = Symbol('eventMonitor')
 
 class AbstractLevel extends EventEmitter {
   constructor (manifest, options) {
@@ -44,6 +48,8 @@ class AbstractLevel extends EventEmitter {
     this[kOptions] = forward
     this[kStatus] = 'opening'
 
+    this.hooks = new DatabaseHooks()
+
     this.supports = supports(manifest, {
       status: true,
       promises: true,
@@ -61,18 +67,33 @@ class AbstractLevel extends EventEmitter {
       iteratorNextv: true,
       iteratorAll: true,
 
+      // TODO: add to level-supports
+      // We don't have to make this an object (e.g. db.supports.hooks.prewrite) because
+      // that information is already available in e.g. db.hooks.prewrite != null.
+      hooks: true,
+
       encodings: manifest.encodings || {},
       events: Object.assign({}, manifest.events, {
         opening: true,
         open: true,
         closing: true,
         closed: true,
+        write: true,
         put: true,
         del: true,
         batch: true,
         clear: true
       })
     })
+
+    // Monitor event listeners
+    this[kEventMonitor] = new EventMonitor(this, [
+      { name: 'write' },
+      { name: 'put', deprecated: true, alt: 'write' },
+      { name: 'del', deprecated: true, alt: 'write' },
+      { name: 'batch', deprecated: true, alt: 'write' },
+      { name: 'ready', deprecated: true, alt: 'open' }
+    ])
 
     this[kTranscoder] = new Transcoder(formats(this))
     this[kKeyEncoding] = this[kTranscoder].encoding(keyEncoding || 'utf8')
@@ -86,7 +107,7 @@ class AbstractLevel extends EventEmitter {
     }
 
     this[kDefaultOptions] = {
-      empty: Object.freeze({}),
+      empty: emptyOptions,
       entry: Object.freeze({
         keyEncoding: this[kKeyEncoding].commonName,
         valueEncoding: this[kValueEncoding].commonName
@@ -96,7 +117,8 @@ class AbstractLevel extends EventEmitter {
       })
     }
 
-    // Let subclass finish its constructor
+    // Before we start opening, let subclass finish its constructor
+    // and allow events and postopen hook functions to be added.
     this.nextTick(() => {
       if (this[kDeferOpen]) {
         this.open({ passive: false }, noop)
@@ -165,6 +187,38 @@ class AbstractLevel extends EventEmitter {
         }
 
         this[kStatus] = 'open'
+
+        // Skip postopen hook if it has 0 hook functions
+        // TODO: write tests
+        // TODO (not urgent): freeze postopen.run before we start opening
+        if (this.hooks.postopen.noop) {
+          return finishOpen()
+        }
+
+        // Run postopen hook and convert promise to callback
+        fromPromise(this.hooks.postopen.run(options), (hookErr) => {
+          // Cancel opening if a hook function threw or closed the database
+          if (hookErr || this[kStatus] !== 'open') {
+            return this.close((closeErr) => {
+              if (hookErr) {
+                callback(new ModuleError('The postopen hook failed on open()', {
+                  code: 'LEVEL_HOOK_ERROR',
+                  cause: combineErrors([hookErr, closeErr])
+                }))
+              } else {
+                // Means the hook function is responsible for handling closeErr
+                callback(new ModuleError('The postopen hook has closed the database', {
+                  code: 'LEVEL_HOOK_ERROR'
+                }))
+              }
+            })
+          }
+
+          finishOpen()
+        })
+      })
+
+      const finishOpen = () => {
         this[kUndefer]()
         this.emit(kLanded)
 
@@ -175,7 +229,7 @@ class AbstractLevel extends EventEmitter {
         if (this[kStatus] === 'open') this.emit('ready')
 
         maybeOpened()
-      })
+      }
     } else if (this[kStatus] === 'open') {
       this.nextTick(maybeOpened)
     } else {
@@ -407,6 +461,11 @@ class AbstractLevel extends EventEmitter {
   }
 
   put (key, value, options, callback) {
+    if (!this.hooks.prewrite.noop) {
+      // Forward to batch() which will run the hook
+      return this.batch([{ type: 'put', key, value }], options, callback)
+    }
+
     callback = getCallback(options, callback)
     callback = fromCallback(callback, kPromise)
     options = getOptions(options, this[kDefaultOptions].entry)
@@ -427,22 +486,42 @@ class AbstractLevel extends EventEmitter {
       return callback[kPromise]
     }
 
+    // Encode data for private API
     const keyEncoding = this.keyEncoding(options.keyEncoding)
     const valueEncoding = this.valueEncoding(options.valueEncoding)
     const keyFormat = keyEncoding.format
     const valueFormat = valueEncoding.format
+    const enableWriteEvent = this[kEventMonitor].write
+    const original = options
 
-    // Forward encoding options
     if (options.keyEncoding !== keyFormat || options.valueEncoding !== valueFormat) {
       options = Object.assign({}, options, { keyEncoding: keyFormat, valueEncoding: valueFormat })
     }
 
-    const mappedKey = this.prefixKey(keyEncoding.encode(key), keyFormat)
-    const mappedValue = valueEncoding.encode(value)
+    const encodedKey = keyEncoding.encode(key)
+    const prefixedKey = this.prefixKey(encodedKey, keyFormat)
+    const encodedValue = valueEncoding.encode(value)
 
-    this._put(mappedKey, mappedValue, options, (err) => {
+    this._put(prefixedKey, encodedValue, options, (err) => {
       if (err) return callback(err)
-      this.emit('put', key, value)
+
+      if (enableWriteEvent) {
+        const op = Object.assign({}, original, {
+          type: 'put',
+          key,
+          value,
+          keyEncoding,
+          valueEncoding,
+          encodedKey,
+          encodedValue
+        })
+
+        this.emit('write', [op])
+      } else {
+        // TODO (semver-major): remove
+        this.emit('put', key, value)
+      }
+
       callback()
     })
 
@@ -454,6 +533,11 @@ class AbstractLevel extends EventEmitter {
   }
 
   del (key, options, callback) {
+    if (!this.hooks.prewrite.noop) {
+      // Forward to batch() which will run the hook
+      return this.batch([{ type: 'del', key }], options, callback)
+    }
+
     callback = getCallback(options, callback)
     callback = fromCallback(callback, kPromise)
     options = getOptions(options, this[kDefaultOptions].key)
@@ -474,17 +558,36 @@ class AbstractLevel extends EventEmitter {
       return callback[kPromise]
     }
 
+    // Encode data for private API
     const keyEncoding = this.keyEncoding(options.keyEncoding)
     const keyFormat = keyEncoding.format
+    const enableWriteEvent = this[kEventMonitor].write
+    const original = options
 
-    // Forward encoding options
     if (options.keyEncoding !== keyFormat) {
       options = Object.assign({}, options, { keyEncoding: keyFormat })
     }
 
-    this._del(this.prefixKey(keyEncoding.encode(key), keyFormat), options, (err) => {
+    const encodedKey = keyEncoding.encode(key)
+    const prefixedKey = this.prefixKey(encodedKey, keyFormat)
+
+    this._del(prefixedKey, options, (err) => {
       if (err) return callback(err)
-      this.emit('del', key)
+
+      if (enableWriteEvent) {
+        const op = Object.assign({}, original, {
+          type: 'del',
+          key,
+          keyEncoding,
+          encodedKey
+        })
+
+        this.emit('write', [op])
+      } else {
+        // TODO (semver-major): remove
+        this.emit('del', key)
+      }
+
       callback()
     })
 
@@ -495,6 +598,9 @@ class AbstractLevel extends EventEmitter {
     this.nextTick(callback)
   }
 
+  // TODO (future): add way for implementations to declare which options are for the
+  // whole batch rather than defaults for individual operations. E.g. the sync option
+  // of classic-level, that should not be copied to individual operations.
   batch (operations, options, callback) {
     if (!arguments.length) {
       if (this[kStatus] === 'opening') return new DefaultChainedBatch(this)
@@ -512,6 +618,7 @@ class AbstractLevel extends EventEmitter {
     callback = fromCallback(callback, kPromise)
     options = getOptions(options, this[kDefaultOptions].empty)
 
+    // TODO (not urgent): freeze prewrite hook
     if (this[kStatus] === 'opening') {
       this.defer(() => this.batch(operations, options, callback))
       return callback[kPromise]
@@ -531,61 +638,131 @@ class AbstractLevel extends EventEmitter {
       return callback[kPromise]
     }
 
-    const mapped = new Array(operations.length)
-    const { keyEncoding: ke, valueEncoding: ve, ...forward } = options
+    const length = operations.length
+    const enablePrewriteHook = !this.hooks.prewrite.noop
+    const enableWriteEvent = this[kEventMonitor].write
+    const publicOperations = enableWriteEvent ? new Array(length) : null
+    const privateOperations = new Array(length)
+    const prewriteBatch = enablePrewriteHook
+      ? new PrewriteBatch(this, privateOperations, publicOperations)
+      : null
 
-    for (let i = 0; i < operations.length; i++) {
-      if (typeof operations[i] !== 'object' || operations[i] === null) {
-        this.nextTick(callback, new TypeError('A batch operation must be an object'))
+    for (let i = 0; i < length; i++) {
+      // Clone the op so that we can freely mutate it. We can't use a class because the
+      // op can have userland properties that we'd have to copy, negating the performance
+      // benefits of a class. So use a plain object.
+      const op = Object.assign({}, options, operations[i])
+
+      // Hook functions can modify op but not its type or sublevel, so cache those
+      const isPut = op.type === 'put'
+      const delegated = op.sublevel != null
+      const db = delegated ? op.sublevel : this
+      const keyError = db._checkKey(op.key)
+
+      if (keyError != null) {
+        this.nextTick(callback, keyError)
         return callback[kPromise]
       }
 
-      const op = Object.assign({}, operations[i])
+      op.keyEncoding = db.keyEncoding(op.keyEncoding)
 
-      if (op.type !== 'put' && op.type !== 'del') {
+      if (isPut) {
+        const valueError = db._checkValue(op.value)
+
+        if (valueError != null) {
+          this.nextTick(callback, valueError)
+          return callback[kPromise]
+        }
+
+        op.valueEncoding = db.valueEncoding(op.valueEncoding)
+      } else if (op.type !== 'del') {
         this.nextTick(callback, new TypeError("A batch operation must have a type property that is 'put' or 'del'"))
         return callback[kPromise]
       }
 
-      const err = this._checkKey(op.key)
+      if (enablePrewriteHook) {
+        try {
+          this.hooks.prewrite.run(op, prewriteBatch)
+        } catch (err) {
+          this.nextTick(callback, new ModuleError('The prewrite hook failed on batch()', {
+            code: 'LEVEL_HOOK_ERROR',
+            cause: err
+          }))
 
-      if (err) {
-        this.nextTick(callback, err)
-        return callback[kPromise]
-      }
-
-      const db = op.sublevel != null ? op.sublevel : this
-      const keyEncoding = db.keyEncoding(op.keyEncoding || ke)
-      const keyFormat = keyEncoding.format
-
-      op.key = db.prefixKey(keyEncoding.encode(op.key), keyFormat)
-      op.keyEncoding = keyFormat
-
-      if (op.type === 'put') {
-        const valueErr = this._checkValue(op.value)
-
-        if (valueErr) {
-          this.nextTick(callback, valueErr)
           return callback[kPromise]
         }
-
-        const valueEncoding = db.valueEncoding(op.valueEncoding || ve)
-
-        op.value = valueEncoding.encode(op.value)
-        op.valueEncoding = valueEncoding.format
       }
+
+      // Encode data for private API
+      // TODO: benchmark a try/catch around this
+      const keyEncoding = op.keyEncoding
+      const encodedKey = keyEncoding.encode(op.key)
+      const keyFormat = keyEncoding.format
+      const prefixedKey = db.prefixKey(encodedKey, keyFormat)
 
       // Prevent double prefixing
-      if (db !== this) {
-        op.sublevel = null
+      if (delegated) op.sublevel = null
+
+      let publicOperation = null
+
+      if (enableWriteEvent) {
+        // Clone op before we mutate it for the private API
+        // TODO (future semver-major): consider sending this shape to private API too
+        // TODO: benchmark if spread syntax is also slow in this particular case
+        publicOperation = Object.assign({}, op)
+
+        if (delegated) {
+          // Ensure emitted data makes sense in the context of this db
+          // TODO: write test (also for chained batch)
+          publicOperation.key = prefixedKey
+          publicOperation.keyEncoding = this.keyEncoding(keyFormat)
+          publicOperation.encodedKey = prefixedKey
+        } else {
+          publicOperation.encodedKey = encodedKey
+        }
+
+        publicOperations[i] = publicOperation
       }
 
-      mapped[i] = op
+      op.key = prefixedKey
+      op.keyEncoding = keyFormat
+
+      if (isPut) {
+        const valueEncoding = op.valueEncoding
+        const encodedValue = valueEncoding.encode(op.value)
+        const valueFormat = valueEncoding.format
+
+        op.value = encodedValue
+        op.valueEncoding = valueFormat
+
+        if (enableWriteEvent) {
+          publicOperation.encodedValue = encodedValue
+
+          if (delegated) {
+            publicOperation.value = encodedValue
+            publicOperation.valueEncoding = this.valueEncoding(valueFormat)
+          }
+        }
+      }
+
+      privateOperations[i] = op
     }
 
-    this._batch(mapped, forward, (err) => {
+    // TODO (future): maybe add separate hook to run on private data. Currently can't work
+    // because prefixing happens too soon; we need to move that logic to the private
+    // API of AbstractSublevel (or reimplement with hooks). TBD how it'd work in chained
+    // batch. Hook would look something like hooks.midwrite.run(privateOperations, ...).
+
+    this._batch(privateOperations, options, (err) => {
       if (err) return callback(err)
-      this.emit('batch', operations)
+
+      if (enableWriteEvent) {
+        this.emit('write', publicOperations)
+      } else if (!enablePrewriteHook) {
+        // TODO (semver-major): remove
+        this.emit('batch', operations)
+      }
+
       callback()
     })
 
@@ -597,7 +774,22 @@ class AbstractLevel extends EventEmitter {
   }
 
   sublevel (name, options) {
-    return this._sublevel(name, AbstractSublevel.defaults(options))
+    const xopts = AbstractSublevel.defaults(options)
+    const sublevel = this._sublevel(name, xopts)
+
+    // TODO: write test
+    if (!this.hooks.newsub.noop) {
+      try {
+        this.hooks.newsub.run(sublevel, xopts)
+      } catch (err) {
+        throw new ModuleError('The newsub hook failed on sublevel()', {
+          code: 'LEVEL_HOOK_ERROR',
+          cause: err
+        })
+      }
+    }
+
+    return sublevel
   }
 
   _sublevel (name, options) {

--- a/abstract-level.js
+++ b/abstract-level.js
@@ -112,8 +112,15 @@ class AbstractLevel extends EventEmitter {
         keyEncoding: this[kKeyEncoding].commonName,
         valueEncoding: this[kValueEncoding].commonName
       }),
+      entryFormat: Object.freeze({
+        keyEncoding: this[kKeyEncoding].format,
+        valueEncoding: this[kValueEncoding].format
+      }),
       key: Object.freeze({
         keyEncoding: this[kKeyEncoding].commonName
+      }),
+      keyFormat: Object.freeze({
+        keyEncoding: this[kKeyEncoding].format
       })
     }
 
@@ -494,7 +501,12 @@ class AbstractLevel extends EventEmitter {
     const enableWriteEvent = this[kEventMonitor].write
     const original = options
 
-    if (options.keyEncoding !== keyFormat || options.valueEncoding !== valueFormat) {
+    // Avoid Object.assign() for default options
+    // TODO: benchmark on classic-level
+    // TODO: also apply this tweak to get() and getMany()
+    if (options === this[kDefaultOptions].entry) {
+      options = this[kDefaultOptions].entryFormat
+    } else if (options.keyEncoding !== keyFormat || options.valueEncoding !== valueFormat) {
       options = Object.assign({}, options, { keyEncoding: keyFormat, valueEncoding: valueFormat })
     }
 
@@ -564,7 +576,10 @@ class AbstractLevel extends EventEmitter {
     const enableWriteEvent = this[kEventMonitor].write
     const original = options
 
-    if (options.keyEncoding !== keyFormat) {
+    // Avoid Object.assign() for default options
+    if (options === this[kDefaultOptions].key) {
+      options = this[kDefaultOptions].keyFormat
+    } else if (options.keyEncoding !== keyFormat) {
       options = Object.assign({}, options, { keyEncoding: keyFormat })
     }
 
@@ -708,7 +723,6 @@ class AbstractLevel extends EventEmitter {
       if (enableWriteEvent) {
         // Clone op before we mutate it for the private API
         // TODO (future semver-major): consider sending this shape to private API too
-        // TODO: benchmark if spread syntax is also slow in this particular case
         publicOperation = Object.assign({}, op)
 
         if (delegated) {

--- a/abstract-level.js
+++ b/abstract-level.js
@@ -196,7 +196,6 @@ class AbstractLevel extends EventEmitter {
         this[kStatus] = 'open'
 
         // Skip postopen hook if it has 0 hook functions
-        // TODO: write tests
         // TODO (not urgent): freeze postopen.run before we start opening
         if (this.hooks.postopen.noop) {
           return finishOpen()

--- a/abstract-level.js
+++ b/abstract-level.js
@@ -697,6 +697,10 @@ class AbstractLevel extends EventEmitter {
       if (enablePrewriteHook) {
         try {
           this.hooks.prewrite.run(op, prewriteBatch)
+
+          // Normalize encodings again in case they were modified
+          op.keyEncoding = db.keyEncoding(op.keyEncoding)
+          if (isPut) op.valueEncoding = db.valueEncoding(op.valueEncoding)
         } catch (err) {
           this.nextTick(callback, new ModuleError('The prewrite hook failed on batch()', {
             code: 'LEVEL_HOOK_ERROR',

--- a/abstract-level.js
+++ b/abstract-level.js
@@ -731,6 +731,7 @@ class AbstractLevel extends EventEmitter {
 
         if (delegated) {
           // Ensure emitted data makes sense in the context of this db
+          // TODO: it doesn't if this db is itself a sublevel
           publicOperation.key = prefixedKey
           publicOperation.keyEncoding = this.keyEncoding(keyFormat)
           publicOperation.encodedKey = prefixedKey

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,9 @@ export {
   AbstractBatchOperation,
   AbstractBatchPutOperation,
   AbstractBatchDelOperation,
-  AbstractClearOptions
+  AbstractClearOptions,
+  AbstractDatabaseHooks,
+  AbstractHook
 } from './types/abstract-level'
 
 export {

--- a/lib/abstract-sublevel.js
+++ b/lib/abstract-sublevel.js
@@ -8,9 +8,11 @@ const {
   AbstractSublevelValueIterator
 } = require('./abstract-sublevel-iterator')
 
-const kPrefix = Symbol('prefix')
-const kUpperBound = Symbol('upperBound')
+const kGlobalPrefix = Symbol('prefix')
+const kLocalPrefix = Symbol('localPrefix')
+const kGlobalUpperBound = Symbol('upperBound')
 const kPrefixRange = Symbol('prefixRange')
+const kRoot = Symbol('root')
 const kParent = Symbol('parent')
 const kUnfix = Symbol('unfix')
 
@@ -45,41 +47,49 @@ module.exports = function ({ AbstractLevel }) {
     constructor (db, name, options) {
       // Don't forward AbstractSublevel options to AbstractLevel
       const { separator, manifest, ...forward } = AbstractSublevel.defaults(options)
-      name = trim(name, separator)
+      const names = [].concat(name).map(name => trim(name, separator))
 
       // Reserve one character between separator and name to give us an upper bound
       const reserved = separator.charCodeAt(0) + 1
-      const parent = db[kParent] || db
+      const root = db[kRoot] || db
 
       // Keys should sort like ['!a!', '!a!!a!', '!a"', '!aa!', '!b!'].
       // Use ASCII for consistent length between string, Buffer and Uint8Array
-      if (!textEncoder.encode(name).every(x => x > reserved && x < 127)) {
-        throw new ModuleError(`Prefix must use bytes > ${reserved} < ${127}`, {
+      if (!names.every(name => textEncoder.encode(name).every(x => x > reserved && x < 127))) {
+        throw new ModuleError(`Sublevel name must use bytes > ${reserved} < ${127}`, {
           code: 'LEVEL_INVALID_PREFIX'
         })
       }
 
-      super(mergeManifests(parent, manifest), forward)
+      super(mergeManifests(db, manifest), forward)
 
-      const prefix = (db.prefix || '') + separator + name + separator
-      const upperBound = prefix.slice(0, -1) + String.fromCharCode(reserved)
+      const localPrefix = names.map(name => separator + name + separator).join('')
+      const globalPrefix = (db.prefix || '') + localPrefix
+      const globalUpperBound = globalPrefix.slice(0, -1) + String.fromCharCode(reserved)
 
-      this[kParent] = parent
-      this[kPrefix] = new MultiFormat(prefix)
-      this[kUpperBound] = new MultiFormat(upperBound)
+      // Most operations are forwarded to the parent database, but clear() and iterators
+      // still forward to the root database - which is older logic and does not yet need
+      // to change, until we add some form of preread or postread hooks.
+      this[kRoot] = root
+      this[kParent] = db
+      this[kGlobalPrefix] = new MultiFormat(globalPrefix)
+      this[kGlobalUpperBound] = new MultiFormat(globalUpperBound)
+      this[kLocalPrefix] = new MultiFormat(localPrefix)
       this[kUnfix] = new Unfixer()
 
-      this.nextTick = parent.nextTick
+      this.nextTick = db.nextTick
     }
 
-    prefixKey (key, keyFormat) {
+    prefixKey (key, keyFormat, local) {
+      const prefix = local ? this[kLocalPrefix] : this[kGlobalPrefix]
+
       if (keyFormat === 'utf8') {
-        return this[kPrefix].utf8 + key
+        return prefix.utf8 + key
       } else if (key.byteLength === 0) {
         // Fast path for empty key (no copy)
-        return this[kPrefix][keyFormat]
+        return prefix[keyFormat]
       } else if (keyFormat === 'view') {
-        const view = this[kPrefix].view
+        const view = prefix.view
         const result = new Uint8Array(view.byteLength + key.byteLength)
 
         result.set(view, 0)
@@ -87,7 +97,7 @@ module.exports = function ({ AbstractLevel }) {
 
         return result
       } else {
-        const buffer = this[kPrefix].buffer
+        const buffer = prefix.buffer
         return Buffer.concat([buffer, key], buffer.byteLength + key.byteLength)
       }
     }
@@ -95,27 +105,31 @@ module.exports = function ({ AbstractLevel }) {
     // Not exposed for now.
     [kPrefixRange] (range, keyFormat) {
       if (range.gte !== undefined) {
-        range.gte = this.prefixKey(range.gte, keyFormat)
+        range.gte = this.prefixKey(range.gte, keyFormat, false)
       } else if (range.gt !== undefined) {
-        range.gt = this.prefixKey(range.gt, keyFormat)
+        range.gt = this.prefixKey(range.gt, keyFormat, false)
       } else {
-        range.gte = this[kPrefix][keyFormat]
+        range.gte = this[kGlobalPrefix][keyFormat]
       }
 
       if (range.lte !== undefined) {
-        range.lte = this.prefixKey(range.lte, keyFormat)
+        range.lte = this.prefixKey(range.lte, keyFormat, false)
       } else if (range.lt !== undefined) {
-        range.lt = this.prefixKey(range.lt, keyFormat)
+        range.lt = this.prefixKey(range.lt, keyFormat, false)
       } else {
-        range.lte = this[kUpperBound][keyFormat]
+        range.lte = this[kGlobalUpperBound][keyFormat]
       }
     }
 
     get prefix () {
-      return this[kPrefix].utf8
+      return this[kGlobalPrefix].utf8
     }
 
     get db () {
+      return this[kRoot]
+    }
+
+    get parent () {
       return this[kParent]
     }
 
@@ -145,30 +159,32 @@ module.exports = function ({ AbstractLevel }) {
       this[kParent].batch(operations, options, callback)
     }
 
+    // TODO: call parent instead of root
     _clear (options, callback) {
       // TODO (refactor): move to AbstractLevel
       this[kPrefixRange](options, options.keyEncoding)
-      this[kParent].clear(options, callback)
+      this[kRoot].clear(options, callback)
     }
 
+    // TODO: call parent instead of root
     _iterator (options) {
       // TODO (refactor): move to AbstractLevel
       this[kPrefixRange](options, options.keyEncoding)
-      const iterator = this[kParent].iterator(options)
-      const unfix = this[kUnfix].get(this[kPrefix].utf8.length, options.keyEncoding)
+      const iterator = this[kRoot].iterator(options)
+      const unfix = this[kUnfix].get(this[kGlobalPrefix].utf8.length, options.keyEncoding)
       return new AbstractSublevelIterator(this, options, iterator, unfix)
     }
 
     _keys (options) {
       this[kPrefixRange](options, options.keyEncoding)
-      const iterator = this[kParent].keys(options)
-      const unfix = this[kUnfix].get(this[kPrefix].utf8.length, options.keyEncoding)
+      const iterator = this[kRoot].keys(options)
+      const unfix = this[kUnfix].get(this[kGlobalPrefix].utf8.length, options.keyEncoding)
       return new AbstractSublevelKeyIterator(this, options, iterator, unfix)
     }
 
     _values (options) {
       this[kPrefixRange](options, options.keyEncoding)
-      const iterator = this[kParent].values(options)
+      const iterator = this[kRoot].values(options)
       return new AbstractSublevelValueIterator(this, options, iterator)
     }
   }

--- a/lib/common.js
+++ b/lib/common.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const ModuleError = require('module-error')
+const deprecations = new Set()
+
 exports.getCallback = function (options, callback) {
   return typeof options === 'function' ? options : callback
 }
@@ -14,4 +17,20 @@ exports.getOptions = function (options, def) {
   }
 
   return {}
+}
+
+exports.emptyOptions = Object.freeze({})
+exports.noop = function () {}
+
+exports.deprecate = function (message) {
+  if (!deprecations.has(message)) {
+    deprecations.add(message)
+
+    // Avoid polyfills
+    const c = globalThis.console
+
+    if (typeof c !== 'undefined' && typeof c.warn === 'function') {
+      c.warn(new ModuleError(message, { code: 'LEVEL_LEGACY' }))
+    }
+  }
 }

--- a/lib/default-chained-batch.js
+++ b/lib/default-chained-batch.js
@@ -7,27 +7,25 @@ const kEncoded = Symbol('encoded')
 // Functional default for chained batch, with support of deferred open
 class DefaultChainedBatch extends AbstractChainedBatch {
   constructor (db) {
-    super(db)
+    // Opt-in to _add() instead of _put() and _del()
+    super(db, { add: true })
     this[kEncoded] = []
   }
 
-  _put (key, value, options) {
-    this[kEncoded].push({ ...options, type: 'put', key, value })
-  }
-
-  _del (key, options) {
-    this[kEncoded].push({ ...options, type: 'del', key })
+  _add (op) {
+    this[kEncoded].push(op)
   }
 
   _clear () {
     this[kEncoded] = []
   }
 
-  // Assumes this[kEncoded] cannot change after write()
   _write (options, callback) {
     if (this.db.status === 'opening') {
       this.db.defer(() => this._write(options, callback))
     } else if (this.db.status === 'open') {
+      // Need to call the private rather than public method, to prevent
+      // recursion, double prefixing, double encoding and double hooks.
       if (this[kEncoded].length === 0) this.nextTick(callback)
       else this.db._batch(this[kEncoded], options, callback)
     } else {

--- a/lib/event-monitor.js
+++ b/lib/event-monitor.js
@@ -1,0 +1,41 @@
+'use strict'
+
+const { deprecate } = require('./common')
+
+exports.EventMonitor = class EventMonitor {
+  constructor (emitter, events) {
+    for (const event of events) {
+      // Track whether listeners are present
+      this[event.name] = false
+
+      // Prepare deprecation message
+      if (event.deprecated) {
+        event.message = `The '${event.name}' event is deprecated in favor of '${event.alt}' and will be removed in a future version of abstract-level`
+      }
+    }
+
+    const map = new Map(events.map(e => [e.name, e]))
+    const monitor = this
+
+    emitter.on('newListener', beforeAdded)
+    emitter.on('removeListener', afterRemoved)
+
+    function beforeAdded (name) {
+      const event = map.get(name)
+
+      if (event !== undefined) {
+        monitor[name] = true
+
+        if (event.deprecated) {
+          deprecate(event.message)
+        }
+      }
+    }
+
+    function afterRemoved (name) {
+      if (map.has(name)) {
+        monitor[name] = this.listenerCount(name) > 0
+      }
+    }
+  }
+}

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -1,0 +1,79 @@
+'use strict'
+
+const { noop } = require('./common')
+
+const kFunctions = Symbol('functions')
+const kAsync = Symbol('async')
+
+class DatabaseHooks {
+  constructor () {
+    this.postopen = new Hook({ async: true })
+    this.prewrite = new Hook({ async: false })
+    this.newsub = new Hook({ async: false })
+  }
+}
+
+class Hook {
+  constructor (options) {
+    this[kAsync] = options.async
+    this[kFunctions] = new Set()
+
+    // Offer a fast way to check if hook functions are present. We could also expose a
+    // size getter, which would be slower, or check it by hook.run !== noop, which would
+    // not allow userland to do the same check.
+    this.noop = true
+    this.run = runner(this)
+  }
+
+  add (fn) {
+    // Validate now rather than in asynchronous code paths
+    assertFunction(fn)
+    this[kFunctions].add(fn)
+    this.noop = false
+    this.run = runner(this)
+  }
+
+  delete (fn) {
+    assertFunction(fn)
+    this[kFunctions].delete(fn)
+    this.noop = this[kFunctions].size === 0
+    this.run = runner(this)
+  }
+}
+
+const assertFunction = function (fn) {
+  if (typeof fn !== 'function') {
+    const hint = fn === null ? 'null' : typeof fn
+    throw new TypeError(`The first argument must be a function, received ${hint}`)
+  }
+}
+
+const runner = function (hook) {
+  if (hook.noop) {
+    return noop
+  } else if (hook[kFunctions].size === 1) {
+    const [fn] = hook[kFunctions]
+    return fn
+  } else if (hook[kAsync]) {
+    // The run function should not reference hook, so that consumers like chained batch
+    // and db.open() can save a reference to hook.run and safely assume it won't change
+    // during their lifetime or async work.
+    const run = async function (functions, ...args) {
+      for (const fn of functions) {
+        await fn(...args)
+      }
+    }
+
+    return run.bind(null, Array.from(hook[kFunctions]))
+  } else {
+    const run = function (functions, ...args) {
+      for (const fn of functions) {
+        fn(...args)
+      }
+    }
+
+    return run.bind(null, Array.from(hook[kFunctions]))
+  }
+}
+
+exports.DatabaseHooks = DatabaseHooks

--- a/lib/prefixes.js
+++ b/lib/prefixes.js
@@ -1,0 +1,12 @@
+'use strict'
+
+exports.prefixDescendantKey = function (key, keyFormat, descendant, ancestor) {
+  // TODO: optimize
+  // TODO: throw when ancestor is not descendant's ancestor?
+  while (descendant !== null && descendant !== ancestor) {
+    key = descendant.prefixKey(key, keyFormat, true)
+    descendant = descendant.parent
+  }
+
+  return key
+}

--- a/lib/prewrite-batch.js
+++ b/lib/prewrite-batch.js
@@ -86,17 +86,6 @@ class PrewriteBatch {
     this[kPrivateOperations].push(op)
     return this
   }
-
-  // TODO: consider removing put() and del() in favor of add()
-  put (key, value, options) {
-    const op = { type: 'put', key, value }
-    return this.add(options != null ? Object.assign({}, options, op) : op)
-  }
-
-  del (key, options) {
-    const op = { type: 'del', key }
-    return this.add(options != null ? Object.assign({}, options, op) : op)
-  }
 }
 
 exports.PrewriteBatch = PrewriteBatch

--- a/lib/prewrite-batch.js
+++ b/lib/prewrite-batch.js
@@ -1,0 +1,102 @@
+'use strict'
+
+const kDb = Symbol('db')
+const kPrivateOperations = Symbol('privateOperations')
+const kPublicOperations = Symbol('publicOperations')
+
+// An interface for prewrite hook functions to add operations
+class PrewriteBatch {
+  constructor (db, privateOperations, publicOperations) {
+    this[kDb] = db
+
+    // Note: if for db.batch([]), these arrays include input operations (or empty slots
+    // for them) but if for chained batch then it does not. Small implementation detail.
+    this[kPrivateOperations] = privateOperations
+    this[kPublicOperations] = publicOperations
+  }
+
+  // TODO: docs
+  add (op) {
+    const isPut = op.type === 'put'
+    const delegated = op.sublevel != null
+    const db = delegated ? op.sublevel : this[kDb]
+
+    const keyError = db._checkKey(op.key)
+    if (keyError != null) throw keyError
+
+    op.keyEncoding = db.keyEncoding(op.keyEncoding)
+
+    if (isPut) {
+      const valueError = db._checkValue(op.value)
+      if (valueError != null) throw valueError
+
+      op.valueEncoding = db.valueEncoding(op.valueEncoding)
+    } else if (op.type !== 'del') {
+      throw new TypeError("A batch operation must have a type property that is 'put' or 'del'")
+    }
+
+    // Encode data for private API
+    const keyEncoding = op.keyEncoding
+    const encodedKey = keyEncoding.encode(op.key)
+    const keyFormat = keyEncoding.format
+    const prefixedKey = db.prefixKey(encodedKey, keyFormat)
+
+    // Prevent double prefixing
+    if (delegated) op.sublevel = null
+
+    let publicOperation = null
+
+    if (this[kPublicOperations] !== null) {
+      // Clone op before we mutate it for the private API
+      publicOperation = Object.assign({}, op)
+
+      if (delegated) {
+        // Ensure emitted data makes sense in the context of this[kDb]
+        publicOperation.key = prefixedKey
+        publicOperation.keyEncoding = this[kDb].keyEncoding(keyFormat)
+        publicOperation.encodedKey = prefixedKey
+      } else {
+        publicOperation.encodedKey = encodedKey
+      }
+
+      this[kPublicOperations].push(publicOperation)
+    }
+
+    op.key = prefixedKey
+    op.keyEncoding = keyFormat
+
+    if (isPut) {
+      const valueEncoding = op.valueEncoding
+      const encodedValue = valueEncoding.encode(op.value)
+      const valueFormat = valueEncoding.format
+
+      op.value = encodedValue
+      op.valueEncoding = valueFormat
+
+      if (publicOperation !== null) {
+        publicOperation.encodedValue = encodedValue
+
+        if (delegated) {
+          publicOperation.value = encodedValue
+          publicOperation.valueEncoding = this[kDb].valueEncoding(valueFormat)
+        }
+      }
+    }
+
+    this[kPrivateOperations].push(op)
+    return this
+  }
+
+  // TODO: consider removing put() and del() in favor of add()
+  put (key, value, options) {
+    const op = { type: 'put', key, value }
+    return this.add(options != null ? Object.assign({}, options, op) : op)
+  }
+
+  del (key, options) {
+    const op = { type: 'del', key }
+    return this.add(options != null ? Object.assign({}, options, op) : op)
+  }
+}
+
+exports.PrewriteBatch = PrewriteBatch

--- a/lib/prewrite-batch.js
+++ b/lib/prewrite-batch.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { prefixDescendantKey } = require('./prefixes')
+
 const kDb = Symbol('db')
 const kPrivateOperations = Symbol('privateOperations')
 const kPublicOperations = Symbol('publicOperations')
@@ -36,9 +38,9 @@ class PrewriteBatch {
 
     // Encode data for private API
     const keyEncoding = op.keyEncoding
-    const encodedKey = keyEncoding.encode(op.key)
+    const preencodedKey = keyEncoding.encode(op.key)
     const keyFormat = keyEncoding.format
-    const prefixedKey = db.prefixKey(encodedKey, keyFormat)
+    const encodedKey = delegated ? prefixDescendantKey(preencodedKey, keyFormat, db, this[kDb]) : preencodedKey
 
     // Prevent double prefixing
     if (delegated) op.sublevel = null
@@ -48,20 +50,18 @@ class PrewriteBatch {
     if (this[kPublicOperations] !== null) {
       // Clone op before we mutate it for the private API
       publicOperation = Object.assign({}, op)
+      publicOperation.encodedKey = encodedKey
 
       if (delegated) {
         // Ensure emitted data makes sense in the context of this[kDb]
-        publicOperation.key = prefixedKey
+        publicOperation.key = encodedKey
         publicOperation.keyEncoding = this[kDb].keyEncoding(keyFormat)
-        publicOperation.encodedKey = prefixedKey
-      } else {
-        publicOperation.encodedKey = encodedKey
       }
 
       this[kPublicOperations].push(publicOperation)
     }
 
-    op.key = prefixedKey
+    op.key = this[kDb].prefixKey(encodedKey, keyFormat, true)
     op.keyEncoding = keyFormat
 
     if (isPut) {

--- a/lib/prewrite-batch.js
+++ b/lib/prewrite-batch.js
@@ -15,7 +15,6 @@ class PrewriteBatch {
     this[kPublicOperations] = publicOperations
   }
 
-  // TODO: docs
   add (op) {
     const isPut = op.type === 'put'
     const delegated = op.sublevel != null

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "is-buffer": "^2.0.5",
     "level-supports": "^4.0.0",
     "level-transcoder": "^1.0.1",
+    "maybe-combine-errors": "^1.0.0",
     "module-error": "^1.0.1",
     "queue-microtask": "^1.2.3"
   },

--- a/test/batch-test.js
+++ b/test/batch-test.js
@@ -309,6 +309,8 @@ exports.events = function (test, testCommon) {
     t.plan(2)
 
     const db = testCommon.factory()
+
+    // Note: may return a transcoder encoding
     const utf8 = db.keyEncoding('utf8')
     await db.open()
 
@@ -323,8 +325,8 @@ exports.events = function (test, testCommon) {
           custom: 123,
           keyEncoding: utf8,
           valueEncoding: utf8,
-          encodedKey: '456',
-          encodedValue: '99'
+          encodedKey: utf8.encode(456),
+          encodedValue: utf8.encode(99)
         }
       ])
     })

--- a/test/batch-test.js
+++ b/test/batch-test.js
@@ -304,57 +304,6 @@ exports.events = function (test, testCommon) {
     await db.batch([{ type: 'put', key: 456, value: 99, custom: 123 }])
     await db.close()
   })
-
-  test('test batch([]) (array-form) emits write event', async function (t) {
-    t.plan(2)
-
-    const db = testCommon.factory()
-
-    // Note: may return a transcoder encoding
-    const utf8 = db.keyEncoding('utf8')
-    await db.open()
-
-    t.ok(db.supports.events.write)
-
-    db.on('write', function (ops) {
-      t.same(ops, [
-        {
-          type: 'put',
-          key: 456,
-          value: 99,
-          custom: 123,
-          keyEncoding: utf8,
-          valueEncoding: utf8,
-          encodedKey: utf8.encode(456),
-          encodedValue: utf8.encode(99)
-        }
-      ])
-    })
-
-    await db.batch([{ type: 'put', key: 456, value: 99, custom: 123 }])
-    return db.close()
-  })
-
-  test('test batch([]) (array-form) emits write event in favor of batch event', async function (t) {
-    t.plan(2)
-
-    const db = testCommon.factory()
-    await db.open()
-
-    db.on('write', function () {
-      t.pass('got write')
-    })
-
-    db.on('batch', function () {
-      t.fail('got batch')
-    })
-
-    // Once we remove the batch event, this test would still pass, but we should then remove it.
-    t.ok(db.supports.events.batch)
-
-    await db.batch([{ type: 'put', key: '123', value: '456' }])
-    return db.close()
-  })
 }
 
 exports.tearDown = function (test, testCommon) {

--- a/test/events/write.js
+++ b/test/events/write.js
@@ -26,11 +26,11 @@ module.exports = function (test, testCommon) {
             t.same(ops, [
               {
                 type: 'put',
-                key: withSublevel ? sublevel.prefixKey(subEncoding.encode('456'), subEncoding.format) : 456,
+                key: withSublevel ? sublevel.prefixKey(subEncoding.encode('456'), subEncoding.format, true) : 456,
                 value: withSublevel ? subEncoding.encode('99') : 99,
                 keyEncoding: db.keyEncoding(withSublevel ? subEncoding.format : 'utf8'),
                 valueEncoding: db.valueEncoding(withSublevel ? subEncoding.format : 'utf8'),
-                encodedKey: withSublevel ? sublevel.prefixKey(subEncoding.encode('456'), subEncoding.format) : dbEncoding.encode('456'),
+                encodedKey: withSublevel ? sublevel.prefixKey(subEncoding.encode('456'), subEncoding.format, true) : dbEncoding.encode('456'),
                 encodedValue: (withSublevel ? subEncoding : dbEncoding).encode('99'),
                 custom: 123,
                 sublevel: null // Should be unset
@@ -73,9 +73,9 @@ module.exports = function (test, testCommon) {
             t.same(ops, [
               {
                 type: 'del',
-                key: withSublevel ? sublevel.prefixKey(subEncoding.encode('456'), subEncoding.format) : 456,
+                key: withSublevel ? sublevel.prefixKey(subEncoding.encode('456'), subEncoding.format, true) : 456,
                 keyEncoding: db.keyEncoding(withSublevel ? subEncoding.format : 'utf8'),
-                encodedKey: withSublevel ? sublevel.prefixKey(subEncoding.encode('456'), subEncoding.format) : dbEncoding.encode('456'),
+                encodedKey: withSublevel ? sublevel.prefixKey(subEncoding.encode('456'), subEncoding.format, true) : dbEncoding.encode('456'),
                 custom: 123,
                 sublevel: null // Should be unset
               }

--- a/test/events/write.js
+++ b/test/events/write.js
@@ -1,0 +1,181 @@
+'use strict'
+
+module.exports = function (test, testCommon) {
+  for (const deferred of [false, true]) {
+    for (const method of ['batch', 'chained batch', 'singular']) {
+      for (const withSublevel of (method === 'singular' ? [false] : [false, true])) {
+        test(`db emits write event for ${method} put operation (deferred: ${deferred}, sublevel: ${withSublevel})`, async function (t) {
+          t.plan(1)
+
+          const db = testCommon.factory()
+          const sublevel = withSublevel ? db.sublevel('abc') : null
+
+          if (!deferred) {
+            await db.open()
+            if (withSublevel) await sublevel.open()
+          }
+
+          // Note: may return a transcoder encoding, which unfortunately makes the below
+          // assertions a little less precise (i.e. we can't compare output data). But
+          // in places where we expect encoded data, we can use strings (rather than
+          // numbers) as the input to encode(), which'll tell us that encoding did happen.
+          const dbEncoding = db.keyEncoding('utf8')
+          const subEncoding = withSublevel ? sublevel.keyEncoding('utf8') : null
+
+          db.on('write', function (ops) {
+            t.same(ops, [
+              {
+                type: 'put',
+                key: withSublevel ? sublevel.prefixKey(subEncoding.encode('456'), subEncoding.format) : 456,
+                value: withSublevel ? subEncoding.encode('99') : 99,
+                keyEncoding: db.keyEncoding(withSublevel ? subEncoding.format : 'utf8'),
+                valueEncoding: db.valueEncoding(withSublevel ? subEncoding.format : 'utf8'),
+                encodedKey: withSublevel ? sublevel.prefixKey(subEncoding.encode('456'), subEncoding.format) : dbEncoding.encode('456'),
+                encodedValue: (withSublevel ? subEncoding : dbEncoding).encode('99'),
+                custom: 123,
+                sublevel: null // Should be unset
+              }
+            ], 'got write event')
+          })
+
+          switch (method) {
+            case 'batch':
+              await db.batch([{ type: 'put', key: 456, value: 99, custom: 123, sublevel }])
+              break
+            case 'chained batch':
+              await db.batch().put(456, 99, { custom: 123, sublevel }).write()
+              break
+            case 'singular':
+              // Does not support sublevel option
+              await db.put(456, 99, { custom: 123, sublevel })
+              break
+          }
+
+          return db.close()
+        })
+
+        test(`db emits write event for ${method} del operation (deferred: ${deferred}, sublevel: ${withSublevel})`, async function (t) {
+          t.plan(1)
+
+          const db = testCommon.factory()
+          const sublevel = withSublevel ? db.sublevel('abc') : null
+
+          if (!deferred) {
+            await db.open()
+            if (withSublevel) await sublevel.open()
+          }
+
+          // See notes above, in the put test
+          const dbEncoding = db.keyEncoding('utf8')
+          const subEncoding = withSublevel ? sublevel.keyEncoding('utf8') : null
+
+          db.on('write', function (ops) {
+            t.same(ops, [
+              {
+                type: 'del',
+                key: withSublevel ? sublevel.prefixKey(subEncoding.encode('456'), subEncoding.format) : 456,
+                keyEncoding: db.keyEncoding(withSublevel ? subEncoding.format : 'utf8'),
+                encodedKey: withSublevel ? sublevel.prefixKey(subEncoding.encode('456'), subEncoding.format) : dbEncoding.encode('456'),
+                custom: 123,
+                sublevel: null // Should be unset
+              }
+            ], 'got write event')
+          })
+
+          switch (method) {
+            case 'batch':
+              await db.batch([{ type: 'del', key: 456, custom: 123, sublevel }])
+              break
+            case 'chained batch':
+              await db.batch().del(456, { custom: 123, sublevel }).write()
+              break
+            case 'singular':
+              // Does not support sublevel option
+              await db.del(456, { custom: 123, sublevel })
+              break
+          }
+
+          return db.close()
+        })
+      }
+    }
+
+    for (const method of ['batch', 'chained batch']) {
+      test(`db emits write event for multiple ${method} operations (deferred: ${deferred})`, async function (t) {
+        t.plan(1)
+
+        const db = testCommon.factory()
+        if (!deferred) await db.open()
+
+        db.on('write', function (ops) {
+          t.same(ops.map(op => op.key), ['a', 'b'], 'got multiple operations in one event')
+        })
+
+        switch (method) {
+          case 'batch':
+            await db.batch([{ type: 'put', key: 'a', value: 'foo' }, { type: 'del', key: 'b' }])
+            break
+          case 'chained batch':
+            await db.batch().put('a', 'foo').del('b').write()
+            break
+        }
+
+        return db.close()
+      })
+    }
+
+    for (const method of ['batch', 'chained batch', 'singular']) {
+      test(`db emits write event for ${method} operation in favor of deprecated events (deferred: ${deferred})`, async function (t) {
+        t.plan(5)
+
+        const keys = []
+        const db = testCommon.factory()
+        if (!deferred) await db.open()
+
+        db.on('write', function (ops) {
+          keys.push(...ops.map(op => op.key))
+        })
+
+        db.on('batch', function () {
+          t.fail('should not get batch event')
+        })
+
+        db.on('put', function () {
+          t.fail('should not get put event')
+        })
+
+        db.on('del', function () {
+          t.fail('should not get del event')
+        })
+
+        // Once we remove the deprecated events, this test would still pass, but we should then remove it.
+        t.ok(db.supports.events.batch, 'supports batch event')
+        t.ok(db.supports.events.put, 'supports put event')
+        t.ok(db.supports.events.del, 'supports del event')
+
+        switch (method) {
+          case 'batch':
+            await db.batch([{ type: 'put', key: 'a', value: 'a' }])
+            t.is(keys.pop(), 'a', 'got write event for batch put')
+            await db.batch([{ type: 'del', key: 'b' }])
+            t.is(keys.pop(), 'b', 'got write event for batch del')
+            break
+          case 'chained batch':
+            await db.batch().put('c', 'c').write()
+            t.is(keys.pop(), 'c', 'got write event for chained batch put')
+            await db.batch().del('d').write()
+            t.is(keys.pop(), 'd', 'got write event for chained batch del')
+            break
+          case 'singular':
+            await db.put('e', 'e')
+            t.is(keys.pop(), 'e', 'got write event for put')
+            await db.del('f')
+            t.is(keys.pop(), 'f', 'got write event for del')
+            break
+        }
+
+        return db.close()
+      })
+    }
+  }
+}

--- a/test/hooks/newsub.js
+++ b/test/hooks/newsub.js
@@ -1,0 +1,57 @@
+'use strict'
+
+const shared = require('./shared')
+
+module.exports = function (test, testCommon) {
+  shared(test, testCommon, 'newsub')
+
+  test('newsub hook function receives sublevel and default options', async function (t) {
+    t.plan(3)
+
+    const db = testCommon.factory()
+
+    let instance
+    db.hooks.newsub.add(function (sublevel, options) {
+      instance = sublevel
+
+      // Recursing is the main purpose of this hook
+      t.ok(sublevel.hooks, 'can access sublevel hooks')
+      t.same(options, { separator: '!' })
+    })
+
+    t.ok(db.sublevel('sub') === instance)
+    return db.close()
+  })
+
+  test('newsub hook function receives userland options', async function (t) {
+    t.plan(1)
+
+    const db = testCommon.factory()
+
+    db.hooks.newsub.add(function (sublevel, options) {
+      t.same(options, { separator: '!', userland: 123 })
+    })
+
+    db.sublevel('sub', { userland: 123 })
+    return db.close()
+  })
+
+  test('db wraps error from newsub hook function', async function (t) {
+    t.plan(2)
+
+    const db = testCommon.factory()
+
+    db.hooks.newsub.add(function (sublevel, options) {
+      throw new Error('test')
+    })
+
+    try {
+      db.sublevel('sub')
+    } catch (err) {
+      t.is(err.code, 'LEVEL_HOOK_ERROR')
+      t.is(err.cause.message, 'test')
+    }
+
+    return db.close()
+  })
+}

--- a/test/hooks/postopen.js
+++ b/test/hooks/postopen.js
@@ -1,6 +1,10 @@
 'use strict'
 
+const shared = require('./shared')
+
 module.exports = function (test, testCommon) {
+  shared(test, testCommon, 'postopen')
+
   test('postopen hook function is called before deferred operations and open event', async function (t) {
     t.plan(5)
 

--- a/test/hooks/postopen.js
+++ b/test/hooks/postopen.js
@@ -1,0 +1,165 @@
+'use strict'
+
+module.exports = function (test, testCommon) {
+  test('postopen hook function is called before deferred operations and open event', async function (t) {
+    t.plan(5)
+
+    const db = testCommon.factory()
+    const order = []
+
+    db.hooks.postopen.add(async function (options) {
+      t.is(db.status, 'open')
+      order.push('postopen')
+    })
+
+    db.on('opening', function () {
+      t.is(db.status, 'opening')
+      order.push('opening')
+    })
+
+    db.defer(function () {
+      t.is(db.status, 'open')
+      order.push('undefer')
+    })
+
+    db.on('open', function () {
+      t.is(db.status, 'open')
+      order.push('open')
+    })
+
+    await db.open()
+    t.same(order, ['opening', 'postopen', 'undefer', 'open'])
+
+    return db.close()
+  })
+
+  test('postopen hook functions are called sequentially', async function (t) {
+    t.plan(1)
+
+    const db = testCommon.factory()
+
+    let waited = false
+    db.hooks.postopen.add(async function (options) {
+      return new Promise(function (resolve) {
+        setTimeout(function () {
+          waited = true
+          resolve()
+        }, 100)
+      })
+    })
+
+    db.hooks.postopen.add(async function (options) {
+      t.ok(waited)
+    })
+
+    await db.open()
+    return db.close()
+  })
+
+  test('postopen hook function receives options from constructor', async function (t) {
+    t.plan(1)
+
+    const db = testCommon.factory({ userland: 123 })
+
+    db.hooks.postopen.add(async function (options) {
+      t.same(options, {
+        createIfMissing: true,
+        errorIfExists: false,
+        userland: 123
+      })
+    })
+
+    await db.open()
+    return db.close()
+  })
+
+  test('postopen hook function receives options from open()', async function (t) {
+    t.plan(1)
+
+    const db = testCommon.factory()
+
+    db.hooks.postopen.add(async function (options) {
+      t.same(options, {
+        createIfMissing: true,
+        errorIfExists: false,
+        userland: 456
+      })
+    })
+
+    await db.open({ userland: 456 })
+    return db.close()
+  })
+
+  test('error from postopen hook function closes the db', async function (t) {
+    t.plan(4)
+
+    const db = testCommon.factory()
+
+    db.hooks.postopen.add(async function (options) {
+      t.is(db.status, 'open')
+      throw new Error('test')
+    })
+
+    try {
+      await db.open()
+    } catch (err) {
+      t.is(db.status, 'closed')
+      t.is(err.code, 'LEVEL_HOOK_ERROR')
+      t.is(err.cause.message, 'test')
+    }
+  })
+
+  test('postopen hook function that fully closes the db results in error', async function (t) {
+    t.plan(5)
+
+    const db = testCommon.factory()
+
+    db.hooks.postopen.add(async function (options) {
+      t.is(db.status, 'open')
+      return db.close()
+    })
+
+    db.on('open', function () {
+      t.fail('should not open')
+    })
+
+    db.on('closed', function () {
+      t.pass('closed')
+    })
+
+    try {
+      await db.open()
+    } catch (err) {
+      t.is(db.status, 'closed')
+      t.is(err.code, 'LEVEL_HOOK_ERROR')
+      t.is(err.message, 'The postopen hook has closed the database')
+    }
+  })
+
+  test('postopen hook function that partially closes the db results in error', async function (t) {
+    t.plan(5)
+
+    const db = testCommon.factory()
+
+    db.hooks.postopen.add(async function (options) {
+      t.is(db.status, 'open')
+      db.close() // Don't await
+    })
+
+    db.on('open', function () {
+      t.fail('should not open')
+    })
+
+    db.on('closed', function () {
+      t.pass('closed')
+    })
+
+    try {
+      await db.open()
+    } catch (err) {
+      t.is(db.status, 'closed')
+      t.is(err.code, 'LEVEL_HOOK_ERROR')
+      t.is(err.message, 'The postopen hook has closed the database')
+    }
+  })
+}

--- a/test/hooks/prewrite.js
+++ b/test/hooks/prewrite.js
@@ -87,6 +87,10 @@ module.exports = function (test, testCommon) {
 
     const db = testCommon.factory()
 
+    // Note: may return a transcoder encoding
+    const utf8 = db.keyEncoding('utf8')
+    const json = db.valueEncoding('json')
+
     db.hooks.prewrite.add(function (op, batch) {
       batch.add({
         type: 'put',
@@ -104,8 +108,8 @@ module.exports = function (test, testCommon) {
           value: 'boop',
           keyEncoding: db.keyEncoding('utf8'),
           valueEncoding: db.valueEncoding('utf8'),
-          encodedKey: 'beep',
-          encodedValue: 'boop'
+          encodedKey: utf8.encode('beep'),
+          encodedValue: utf8.encode('boop')
         },
         {
           type: 'put',
@@ -113,8 +117,8 @@ module.exports = function (test, testCommon) {
           value: { abc: 123 },
           keyEncoding: db.keyEncoding('utf8'),
           valueEncoding: db.valueEncoding('json'),
-          encodedKey: 'from-hook',
-          encodedValue: '{"abc":123}'
+          encodedKey: utf8.encode('from-hook'),
+          encodedValue: json.encode({ abc: 123 })
         }
       ])
     })

--- a/test/hooks/prewrite.js
+++ b/test/hooks/prewrite.js
@@ -1,130 +1,452 @@
 'use strict'
 
 module.exports = function (test, testCommon) {
-  // TODO: test modification of op
-  test('hooks.prewrite triggered by put', async function (t) {
-    t.plan(3)
+  for (const deferred of [false, true]) {
+    test(`prewrite hook function receives put op (deferred: ${deferred})`, async function (t) {
+      t.plan(3)
 
-    const db = testCommon.factory()
+      const db = testCommon.factory()
+      if (!deferred) await db.open()
 
-    db.hooks.prewrite.add(function (op, batch) {
-      t.same(op, {
-        type: 'put',
-        key: 'beep',
-        value: 'boop',
-        keyEncoding: db.keyEncoding('utf8'),
-        valueEncoding: db.valueEncoding('utf8')
-      })
-    })
-
-    await db.put('beep', 'boop')
-    await db.batch([{ type: 'put', key: 'beep', value: 'boop' }])
-    await db.batch().put('beep', 'boop').write()
-  })
-
-  test('hooks.prewrite triggered by put with custom encodings and userland option', async function (t) {
-    t.plan(3)
-
-    const db = testCommon.factory()
-
-    db.hooks.prewrite.add(function (op, batch) {
-      t.same(op, {
-        type: 'put',
-        key: 123, // Should not be JSON-encoded
-        value: 'boop',
-        keyEncoding: db.keyEncoding('json'),
-        valueEncoding: db.valueEncoding('json'),
-        userland: 456
-      })
-    })
-
-    await db.put(123, 'boop', { keyEncoding: 'json', valueEncoding: 'json', userland: 456 })
-    await db.batch([{ type: 'put', key: 123, value: 'boop', keyEncoding: 'json', valueEncoding: 'json', userland: 456 }])
-    await db.batch().put(123, 'boop', { keyEncoding: 'json', valueEncoding: 'json', userland: 456 }).write()
-  })
-
-  test('hooks.prewrite triggered by del', async function (t) {
-    t.plan(3)
-
-    const db = testCommon.factory()
-
-    db.hooks.prewrite.add(function (op, batch) {
-      t.same(op, {
-        type: 'del',
-        key: 'beep',
-        keyEncoding: db.keyEncoding('utf8')
-      })
-    })
-
-    await db.del('beep')
-    await db.batch([{ type: 'del', key: 'beep' }])
-    await db.batch().del('beep').write()
-  })
-
-  test('hooks.prewrite triggered by del with custom encodings and userland option', async function (t) {
-    t.plan(3)
-
-    const db = testCommon.factory()
-
-    db.hooks.prewrite.add(function (op, batch) {
-      t.same(op, {
-        type: 'del',
-        key: 123, // Should not be JSON-encoded
-        keyEncoding: db.keyEncoding('json'),
-        userland: 456
-      })
-    })
-
-    await db.del(123, { keyEncoding: 'json', userland: 456 })
-    await db.batch([{ type: 'del', key: 123, keyEncoding: 'json', userland: 456 }])
-    await db.batch().del(123, { keyEncoding: 'json', userland: 456 }).write()
-  })
-
-  // No need to separately test a del trigger; we do that above
-  // TODO: test order of operations
-  test('hooks.prewrite can add operations', async function (t) {
-    t.plan(3)
-
-    const db = testCommon.factory()
-
-    // Note: may return a transcoder encoding
-    const utf8 = db.keyEncoding('utf8')
-    const json = db.valueEncoding('json')
-
-    db.hooks.prewrite.add(function (op, batch) {
-      batch.add({
-        type: 'put',
-        key: 'from-hook',
-        value: { abc: 123 },
-        valueEncoding: 'json'
-      })
-    })
-
-    db.on('write', function (ops) {
-      t.same(ops, [
-        {
+      db.hooks.prewrite.add(function (op, batch) {
+        t.same(op, {
           type: 'put',
           key: 'beep',
           value: 'boop',
           keyEncoding: db.keyEncoding('utf8'),
-          valueEncoding: db.valueEncoding('utf8'),
-          encodedKey: utf8.encode('beep'),
-          encodedValue: utf8.encode('boop')
-        },
-        {
+          valueEncoding: db.valueEncoding('utf8')
+        })
+      })
+
+      await db.put('beep', 'boop')
+      await db.batch([{ type: 'put', key: 'beep', value: 'boop' }])
+      await db.batch().put('beep', 'boop').write()
+
+      return db.close()
+    })
+
+    test(`prewrite hook function receives del op (deferred: ${deferred})`, async function (t) {
+      t.plan(3)
+
+      const db = testCommon.factory()
+      if (!deferred) await db.open()
+
+      db.hooks.prewrite.add(function (op, batch) {
+        t.same(op, {
+          type: 'del',
+          key: 'beep',
+          keyEncoding: db.keyEncoding('utf8')
+        })
+      })
+
+      await db.del('beep')
+      await db.batch([{ type: 'del', key: 'beep' }])
+      await db.batch().del('beep').write()
+
+      return db.close()
+    })
+
+    test(`prewrite hook function receives put op with custom encodings and userland option (deferred: ${deferred})`, async function (t) {
+      t.plan(3)
+
+      const db = testCommon.factory()
+      if (!deferred) await db.open()
+
+      db.hooks.prewrite.add(function (op, batch) {
+        t.same(op, {
+          type: 'put',
+          key: 123, // Should not be JSON-encoded
+          value: 'boop',
+          keyEncoding: db.keyEncoding('json'),
+          valueEncoding: db.valueEncoding('json'),
+          userland: 456
+        })
+      })
+
+      await db.put(123, 'boop', { keyEncoding: 'json', valueEncoding: 'json', userland: 456 })
+      await db.batch([{ type: 'put', key: 123, value: 'boop', keyEncoding: 'json', valueEncoding: 'json', userland: 456 }])
+      await db.batch().put(123, 'boop', { keyEncoding: 'json', valueEncoding: 'json', userland: 456 }).write()
+
+      return db.close()
+    })
+
+    test(`prewrite hook function receives del op with custom encodings and userland option (deferred: ${deferred})`, async function (t) {
+      t.plan(3)
+
+      const db = testCommon.factory()
+      if (!deferred) await db.open()
+
+      db.hooks.prewrite.add(function (op, batch) {
+        t.same(op, {
+          type: 'del',
+          key: 123, // Should not be JSON-encoded
+          keyEncoding: db.keyEncoding('json'),
+          userland: 456
+        })
+      })
+
+      await db.del(123, { keyEncoding: 'json', userland: 456 })
+      await db.batch([{ type: 'del', key: 123, keyEncoding: 'json', userland: 456 }])
+      await db.batch().del(123, { keyEncoding: 'json', userland: 456 }).write()
+
+      return db.close()
+    })
+
+    test(`prewrite hook function can modify put operation (deferred: ${deferred})`, async function (t) {
+      t.plan(10 * 3)
+
+      const db = testCommon.factory({ keyEncoding: 'json', valueEncoding: 'utf8' })
+      if (!deferred) await db.open()
+
+      db.hooks.prewrite.add(function (op, batch) {
+        t.is(op.keyEncoding, db.keyEncoding('json'))
+        t.is(op.valueEncoding, db.valueEncoding('utf8'))
+
+        op.key = '456'
+        op.value = { x: 1 }
+
+        // Flip the encodings
+        op.keyEncoding = 'utf8'
+        op.valueEncoding = 'json'
+
+        // Test adding a userland option
+        op.userland = 456
+      })
+
+      db.on('write', function (ops) {
+        t.is(ops.length, 1)
+        t.is(ops[0].key, '456')
+        t.same(ops[0].value, { x: 1 })
+        t.is(ops[0].keyEncoding, db.keyEncoding('utf8'))
+        t.is(ops[0].valueEncoding, db.valueEncoding('json'))
+        t.same(ops[0].encodedKey, db.keyEncoding('utf8').encode('456'))
+        t.same(ops[0].encodedValue, db.valueEncoding('json').encode({ x: 1 }))
+        t.is(ops[0].userland, 456)
+      })
+
+      await db.put(123, 'boop')
+      await db.batch([{ type: 'put', key: 123, value: 'boop' }])
+      await db.batch().put(123, 'boop').write()
+
+      return db.close()
+    })
+
+    test(`prewrite hook function can modify del operation (deferred: ${deferred})`, async function (t) {
+      t.plan(6 * 3)
+
+      const db = testCommon.factory({ keyEncoding: 'json' })
+      if (!deferred) await db.open()
+
+      db.hooks.prewrite.add(function (op, batch) {
+        t.is(op.keyEncoding, db.keyEncoding('json'))
+
+        op.key = '456'
+        op.keyEncoding = 'utf8'
+
+        // Test adding a userland option
+        op.userland = 456
+      })
+
+      db.on('write', function (ops) {
+        t.is(ops.length, 1)
+        t.is(ops[0].key, '456')
+        t.is(ops[0].keyEncoding, db.keyEncoding('utf8'))
+        t.same(ops[0].encodedKey, db.keyEncoding('utf8').encode('456'))
+        t.is(ops[0].userland, 456)
+      })
+
+      await db.del(123)
+      await db.batch([{ type: 'del', key: 123 }])
+      await db.batch().del(123).write()
+
+      return db.close()
+    })
+
+    test(`prewrite hook function triggered by put can add operations (deferred: ${deferred})`, async function (t) {
+      t.plan(3)
+
+      const db = testCommon.factory()
+      if (!deferred) await db.open()
+
+      // Note: may return a transcoder encoding
+      const utf8 = db.keyEncoding('utf8')
+      const json = db.valueEncoding('json')
+
+      db.hooks.prewrite.add(function (op, batch) {
+        batch.add({
           type: 'put',
           key: 'from-hook',
           value: { abc: 123 },
-          keyEncoding: db.keyEncoding('utf8'),
-          valueEncoding: db.valueEncoding('json'),
-          encodedKey: utf8.encode('from-hook'),
-          encodedValue: json.encode({ abc: 123 })
-        }
-      ])
+          valueEncoding: 'json'
+        })
+      })
+
+      db.on('write', function (ops) {
+        t.same(ops, [
+          {
+            type: 'put',
+            key: 'beep',
+            value: 'boop',
+            keyEncoding: db.keyEncoding('utf8'),
+            valueEncoding: db.valueEncoding('utf8'),
+            encodedKey: utf8.encode('beep'),
+            encodedValue: utf8.encode('boop')
+          },
+          {
+            type: 'put',
+            key: 'from-hook',
+            value: { abc: 123 },
+            keyEncoding: db.keyEncoding('utf8'),
+            valueEncoding: db.valueEncoding('json'),
+            encodedKey: utf8.encode('from-hook'),
+            encodedValue: json.encode({ abc: 123 })
+          }
+        ])
+      })
+
+      await db.put('beep', 'boop')
+      await db.batch([{ type: 'put', key: 'beep', value: 'boop' }])
+      await db.batch().put('beep', 'boop').write()
+
+      return db.close()
     })
 
-    await db.put('beep', 'boop')
-    await db.batch([{ type: 'put', key: 'beep', value: 'boop' }])
-    await db.batch().put('beep', 'boop').write()
+    test(`prewrite hook function triggered by del can add operations (deferred: ${deferred})`, async function (t) {
+      t.plan(3)
+
+      const db = testCommon.factory()
+      if (!deferred) await db.open()
+
+      // Note: may return a transcoder encoding
+      const utf8 = db.keyEncoding('utf8')
+
+      db.hooks.prewrite.add(function (op, batch) {
+        batch.add({ type: 'del', key: 'from-hook' })
+      })
+
+      db.on('write', function (ops) {
+        t.same(ops, [
+          {
+            type: 'del',
+            key: 'beep',
+            keyEncoding: db.keyEncoding('utf8'),
+            encodedKey: utf8.encode('beep')
+          },
+          {
+            type: 'del',
+            key: 'from-hook',
+            keyEncoding: db.keyEncoding('utf8'),
+            encodedKey: utf8.encode('from-hook')
+          }
+        ])
+      })
+
+      await db.del('beep')
+      await db.batch([{ type: 'del', key: 'beep' }])
+      await db.batch().del('beep').write()
+
+      return db.close()
+    })
+
+    test(`prewrite hook function is called once for every input operation (deferred: ${deferred})`, async function (t) {
+      t.plan(2)
+
+      const calls = []
+      const db = testCommon.factory()
+      if (!deferred) await db.open()
+
+      db.hooks.prewrite.add(function (op, batch) {
+        calls.push(op.key)
+      })
+
+      await db.batch([{ type: 'del', key: '1' }, { type: 'put', key: '2', value: '123' }])
+      t.same(calls.splice(0, calls.length), ['1', '2'])
+
+      await db.batch().del('1').put('2', '123').write()
+      t.same(calls.splice(0, calls.length), ['1', '2'])
+
+      return db.close()
+    })
+
+    test(`prewrite hook adds operations after input operations (deferred: ${deferred})`, async function (t) {
+      t.plan(2)
+
+      const db = testCommon.factory()
+      if (!deferred) await db.open()
+
+      db.hooks.prewrite.add(function (op, batch) {
+        if (op.key === 'input1') {
+          batch
+            .add({ type: 'del', key: 'hook1' })
+            .add({ type: 'del', key: 'hook2' })
+            .add({ type: 'put', key: 'hook3', value: 'foo' })
+        }
+      })
+
+      db.on('write', function (ops) {
+        t.same(ops.map(op => op.key), [
+          'input1', 'input2', 'hook1', 'hook2', 'hook3'
+        ], 'order is correct')
+      })
+
+      await db.batch([{ type: 'del', key: 'input1' }, { type: 'put', key: 'input2', value: '123' }])
+      await db.batch().del('input1').put('input2', '123').write()
+
+      return db.close()
+    })
+
+    test(`prewrite hook does not copy input options to added operations (deferred: ${deferred})`, async function (t) {
+      t.plan(6)
+
+      const db = testCommon.factory()
+      if (!deferred) await db.open()
+
+      db.hooks.prewrite.add(function (op, batch) {
+        batch.add({ type: 'put', key: 'from-hook-a', value: 'xyz' })
+        batch.add({ type: 'del', key: 'from-hook-b' })
+      })
+
+      db.on('write', function (ops) {
+        const relevant = ops.map(op => {
+          return {
+            key: op.key,
+            hasOption: 'userland' in op,
+            keyEncoding: op.keyEncoding.commonName
+          }
+        })
+
+        t.same(relevant, [
+          {
+            key: 'input-a',
+            keyEncoding: 'json',
+            hasOption: true
+          },
+          {
+            key: 'from-hook-a',
+            keyEncoding: 'utf8', // Should be the database default (2x)
+            hasOption: false
+          },
+          {
+            key: 'from-hook-b',
+            keyEncoding: 'utf8',
+            hasOption: false
+          }
+        ])
+      })
+
+      await db.put('input-a', 'boop', { keyEncoding: 'json', userland: 123 })
+      await db.batch([{ type: 'put', key: 'input-a', value: 'boop', keyEncoding: 'json', userland: 123 }])
+      await db.batch().put('input-a', 'boop', { keyEncoding: 'json', userland: 123 }).write()
+
+      await db.del('input-a', { keyEncoding: 'json', userland: 123 })
+      await db.batch([{ type: 'del', key: 'input-a', keyEncoding: 'json', userland: 123 }])
+      await db.batch().del('input-a', { keyEncoding: 'json', userland: 123 }).write()
+
+      return db.close()
+    })
+
+    test(`error thrown from prewrite hook function is catched (deferred: ${deferred})`, async function (t) {
+      t.plan(6 * 2)
+
+      const db = testCommon.factory()
+      if (!deferred) await db.open()
+
+      db.hooks.prewrite.add(function (op, batch) {
+        throw new Error('test')
+      })
+
+      const verify = (err) => {
+        t.is(err.code, 'LEVEL_HOOK_ERROR')
+        t.is(err.cause.message, 'test')
+      }
+
+      await db.batch([{ type: 'del', key: '1' }]).catch(verify)
+      await db.batch([{ type: 'put', key: '1', value: '2' }]).catch(verify)
+
+      const batch1 = db.batch()
+      const batch2 = db.batch()
+
+      try { batch1.del('1') } catch (err) { verify(err) }
+      try { batch2.put('1', '2') } catch (err) { verify(err) }
+
+      await batch1.close()
+      await batch2.close()
+
+      await db.del('1').catch(verify)
+      await db.put('1', '2').catch(verify)
+
+      return db.close()
+    })
+  }
+
+  test('operations added by prewrite hook function count towards chained batch length', async function (t) {
+    t.plan(2)
+
+    const db = testCommon.factory()
+    await db.open()
+
+    db.hooks.prewrite.add(function (op, batch) {
+      batch.add({ type: 'del', key: 'hook1' })
+    })
+
+    const batch = db.batch()
+
+    batch.del('input1')
+    t.is(batch.length, 2)
+
+    batch.put('input2', 'foo')
+    t.is(batch.length, 4)
+
+    await batch.close()
+    return db.close()
+  })
+
+  test('operations added by prewrite hook function can be cleared from chained batch', async function (t) {
+    t.plan(3)
+
+    const db = testCommon.factory()
+    await db.open()
+
+    db.hooks.prewrite.add(function (op, batch) {
+      batch.add({ type: 'put', key: 'x', value: 'y' })
+    })
+
+    const batch = db.batch()
+
+    batch.del('a')
+    t.is(batch.length, 2)
+
+    batch.clear()
+    t.is(batch.length, 0)
+
+    db.on('write', t.fail.bind(t))
+    await batch.write()
+
+    t.same(await db.keys().all(), [], 'did not write to db')
+    return db.close()
+  })
+
+  test('prewrite hook function is not called for earlier chained batch', async function (t) {
+    t.plan(2)
+
+    const db = testCommon.factory()
+    await db.open()
+
+    const calls = []
+    const batchBefore = db.batch()
+
+    db.hooks.prewrite.add(function (op, batch) {
+      calls.push(op.key)
+    })
+
+    batchBefore.del('before')
+    t.same(calls, [])
+
+    const batchAfter = db.batch()
+    batchAfter.del('after')
+    t.same(calls, ['after'])
+
+    await Promise.all([batchBefore.close(), batchAfter.close()])
+    return db.close()
   })
 }

--- a/test/hooks/prewrite.js
+++ b/test/hooks/prewrite.js
@@ -1,0 +1,121 @@
+'use strict'
+
+module.exports = function (test, testCommon) {
+  // TODO: test modification of op
+  test('hooks.prewrite triggered by put', async function (t) {
+    t.plan(3)
+
+    const db = testCommon.factory()
+
+    db.hooks.prewrite.add(function (op, batch) {
+      t.same(op, {
+        type: 'put',
+        key: 'beep',
+        value: 'boop',
+        keyEncoding: db.keyEncoding('utf8'),
+        valueEncoding: db.valueEncoding('utf8')
+      })
+    })
+
+    await db.put('beep', 'boop')
+    await db.batch([{ type: 'put', key: 'beep', value: 'boop' }])
+    await db.batch().put('beep', 'boop').write()
+  })
+
+  test('hooks.prewrite triggered by put with custom encodings and userland option', async function (t) {
+    t.plan(3)
+
+    const db = testCommon.factory()
+
+    db.hooks.prewrite.add(function (op, batch) {
+      t.same(op, {
+        type: 'put',
+        key: 123, // Should not be JSON-encoded
+        value: 'boop',
+        keyEncoding: db.keyEncoding('json'),
+        valueEncoding: db.valueEncoding('json'),
+        userland: 456
+      })
+    })
+
+    await db.put(123, 'boop', { keyEncoding: 'json', valueEncoding: 'json', userland: 456 })
+    await db.batch([{ type: 'put', key: 123, value: 'boop', keyEncoding: 'json', valueEncoding: 'json', userland: 456 }])
+    await db.batch().put(123, 'boop', { keyEncoding: 'json', valueEncoding: 'json', userland: 456 }).write()
+  })
+
+  test('hooks.prewrite triggered by del', async function (t) {
+    t.plan(3)
+
+    const db = testCommon.factory()
+
+    db.hooks.prewrite.add(function (op, batch) {
+      t.same(op, {
+        type: 'del',
+        key: 'beep',
+        keyEncoding: db.keyEncoding('utf8')
+      })
+    })
+
+    await db.del('beep')
+    await db.batch([{ type: 'del', key: 'beep' }])
+    await db.batch().del('beep').write()
+  })
+
+  test('hooks.prewrite triggered by del with custom encodings and userland option', async function (t) {
+    t.plan(3)
+
+    const db = testCommon.factory()
+
+    db.hooks.prewrite.add(function (op, batch) {
+      t.same(op, {
+        type: 'del',
+        key: 123, // Should not be JSON-encoded
+        keyEncoding: db.keyEncoding('json'),
+        userland: 456
+      })
+    })
+
+    await db.del(123, { keyEncoding: 'json', userland: 456 })
+    await db.batch([{ type: 'del', key: 123, keyEncoding: 'json', userland: 456 }])
+    await db.batch().del(123, { keyEncoding: 'json', userland: 456 }).write()
+  })
+
+  // No need to separately test a del trigger; we do that above
+  // TODO: test order of operations
+  test('hooks.prewrite can add operations', async function (t) {
+    t.plan(3)
+
+    const db = testCommon.factory()
+
+    db.hooks.prewrite.add(function (op, batch) {
+      batch.put('from-hook', { abc: 123 }, { valueEncoding: 'json' })
+    })
+
+    db.on('write', function (ops) {
+      t.same(ops, [
+        {
+          type: 'put',
+          key: 'beep',
+          value: 'boop',
+          keyEncoding: db.keyEncoding('utf8'),
+          valueEncoding: db.valueEncoding('utf8'),
+          encodedKey: 'beep',
+          encodedValue: 'boop'
+        },
+        {
+          type: 'put',
+          key: 'from-hook',
+          value: { abc: 123 },
+          keyEncoding: db.keyEncoding('utf8'),
+          valueEncoding: db.valueEncoding('json'),
+          encodedKey: 'from-hook',
+          encodedValue: '{"abc":123}'
+        }
+      ])
+    })
+
+    await db.put('beep', 'boop')
+    await db.batch([{ type: 'put', key: 'beep', value: 'boop' }])
+    await db.batch().put('beep', 'boop').write()
+  })
+}

--- a/test/hooks/prewrite.js
+++ b/test/hooks/prewrite.js
@@ -88,7 +88,12 @@ module.exports = function (test, testCommon) {
     const db = testCommon.factory()
 
     db.hooks.prewrite.add(function (op, batch) {
-      batch.put('from-hook', { abc: 123 }, { valueEncoding: 'json' })
+      batch.add({
+        type: 'put',
+        key: 'from-hook',
+        value: { abc: 123 },
+        valueEncoding: 'json'
+      })
     })
 
     db.on('write', function (ops) {

--- a/test/hooks/prewrite.js
+++ b/test/hooks/prewrite.js
@@ -1,6 +1,10 @@
 'use strict'
 
+const shared = require('./shared')
+
 module.exports = function (test, testCommon) {
+  shared(test, testCommon, 'prewrite')
+
   for (const deferred of [false, true]) {
     test(`prewrite hook function receives put op (deferred: ${deferred})`, async function (t) {
       t.plan(3)

--- a/test/hooks/shared.js
+++ b/test/hooks/shared.js
@@ -1,0 +1,38 @@
+'use strict'
+
+module.exports = function (test, testCommon, hook) {
+  test(`can add and remove functions to/from ${hook} hook`, async function (t) {
+    const db = testCommon.factory()
+    const fn1 = function () {}
+    const fn2 = function () {}
+
+    t.is(db.hooks[hook].noop, true, 'is initially a noop')
+    t.is(typeof db.hooks[hook].run, 'function')
+
+    db.hooks[hook].add(fn1)
+    t.is(db.hooks[hook].noop, false, 'not a noop')
+    t.is(typeof db.hooks[hook].run, 'function')
+
+    db.hooks[hook].add(fn2)
+    t.is(db.hooks[hook].noop, false, 'not a noop')
+    t.is(typeof db.hooks[hook].run, 'function')
+
+    db.hooks[hook].delete(fn1)
+    t.is(db.hooks[hook].noop, false, 'not a noop')
+    t.is(typeof db.hooks[hook].run, 'function')
+
+    db.hooks[hook].delete(fn2)
+    t.is(db.hooks[hook].noop, true, 'is a noop again')
+    t.is(typeof db.hooks[hook].run, 'function')
+
+    for (const invalid of [null, undefined, 123]) {
+      t.throws(() => db.hooks[hook].add(invalid), (err) => err.name === 'TypeError')
+      t.throws(() => db.hooks[hook].delete(invalid), (err) => err.name === 'TypeError')
+    }
+
+    t.is(db.hooks[hook].noop, true, 'still a noop')
+    t.is(typeof db.hooks[hook].run, 'function')
+
+    return db.close()
+  })
+}

--- a/test/index.js
+++ b/test/index.js
@@ -56,6 +56,7 @@ function suite (options) {
 
   require('./events/write')(test, testCommon)
   require('./hooks/postopen')(test, testCommon)
+  require('./hooks/newsub')(test, testCommon)
   require('./hooks/prewrite')(test, testCommon)
 
   // Run the same suite on a sublevel

--- a/test/index.js
+++ b/test/index.js
@@ -54,6 +54,7 @@ function suite (options) {
   require('./clear-range-test').all(test, testCommon)
   require('./sublevel-test').all(test, testCommon)
 
+  require('./events/write')(test, testCommon)
   require('./hooks/prewrite')(test, testCommon)
 
   // Run the same suite on a sublevel

--- a/test/index.js
+++ b/test/index.js
@@ -54,6 +54,8 @@ function suite (options) {
   require('./clear-range-test').all(test, testCommon)
   require('./sublevel-test').all(test, testCommon)
 
+  require('./hooks/prewrite')(test, testCommon)
+
   // Run the same suite on a sublevel
   if (!testCommon.internals[kSublevels]) {
     const factory = testCommon.factory

--- a/test/index.js
+++ b/test/index.js
@@ -55,6 +55,7 @@ function suite (options) {
   require('./sublevel-test').all(test, testCommon)
 
   require('./events/write')(test, testCommon)
+  require('./hooks/postopen')(test, testCommon)
   require('./hooks/prewrite')(test, testCommon)
 
   // Run the same suite on a sublevel

--- a/test/self.js
+++ b/test/self.js
@@ -480,7 +480,7 @@ test('test batch([]) (array-form) extensibility', function (t) {
     t.equal(spy.callCount, 2, 'got _batch() call')
     t.equal(spy.getCall(1).thisValue, test, '`this` on _batch() was correct')
     t.equal(spy.getCall(1).args.length, 3, 'got three arguments')
-    t.deepEqual(spy.getCall(1).args[0], expectedArray, 'got expected array argument')
+    t.deepEqual(spy.getCall(1).args[0], expectedArray.map(o => ({ ...expectedOptions, ...o })), 'got expected array argument')
     t.deepEqual(spy.getCall(1).args[1], expectedOptions, 'got expected options argument')
     t.equal(typeof spy.getCall(1).args[2], 'function', 'got callback argument')
 
@@ -688,7 +688,7 @@ test('test AbstractChainedBatch#write() extensibility with options', function (t
 })
 
 test('test AbstractChainedBatch#put() extensibility', function (t) {
-  t.plan(7)
+  t.plan(8)
 
   const spy = sinon.spy()
   const expectedKey = 'key'
@@ -705,7 +705,11 @@ test('test AbstractChainedBatch#put() extensibility', function (t) {
     t.equal(spy.getCall(0).args.length, 3, 'got 3 arguments')
     t.equal(spy.getCall(0).args[0], expectedKey, 'got expected key argument')
     t.equal(spy.getCall(0).args[1], expectedValue, 'got expected value argument')
-    t.same(spy.getCall(0).args[2], { keyEncoding: 'utf8', valueEncoding: 'utf8' }, 'got expected options argument')
+
+    // May contain more options, just because it's cheaper to not remove them
+    t.is(spy.getCall(0).args[2].keyEncoding, 'utf8', 'got expected keyEncoding option')
+    t.is(spy.getCall(0).args[2].valueEncoding, 'utf8', 'got expected valueEncoding option')
+
     t.equal(returnValue, test, 'get expected return value')
   })
 })
@@ -726,7 +730,10 @@ test('test AbstractChainedBatch#del() extensibility', function (t) {
     t.equal(spy.getCall(0).thisValue, test, '`this` on _del() was correct')
     t.equal(spy.getCall(0).args.length, 2, 'got 2 arguments')
     t.equal(spy.getCall(0).args[0], expectedKey, 'got expected key argument')
-    t.same(spy.getCall(0).args[1], { keyEncoding: 'utf8' }, 'got expected options argument')
+
+    // May contain more options, just because it's cheaper to not remove them
+    t.is(spy.getCall(0).args[1].keyEncoding, 'utf8', 'got expected keyEncoding option')
+
     t.equal(returnValue, test, 'get expected return value')
   })
 })

--- a/test/self/encoding-test.js
+++ b/test/self/encoding-test.js
@@ -222,7 +222,7 @@ for (const deferred of [false, true]) {
 
   // NOTE: adapted from encoding-down
   test(`chainedBatch.put() and del() encode utf8 key and value (deferred: ${deferred})`, async function (t) {
-    t.plan(deferred ? 2 : 4)
+    t.plan(deferred ? 2 : 5)
 
     let db
 
@@ -243,11 +243,14 @@ for (const deferred of [false, true]) {
           return mockChainedBatch(this, {
             _put: function (key, value, options) {
               t.same({ key, value }, { key: '1', value: '2' })
-              t.same(options, { keyEncoding: 'utf8', valueEncoding: 'utf8' })
+
+              // May contain additional options just because it's cheaper to not remove them
+              t.is(options.keyEncoding, 'utf8')
+              t.is(options.valueEncoding, 'utf8')
             },
             _del: function (key, options) {
               t.is(key, '3')
-              t.same(options, { keyEncoding: 'utf8' })
+              t.is(options.keyEncoding, 'utf8')
             }
           })
         }
@@ -260,7 +263,7 @@ for (const deferred of [false, true]) {
 
   // NOTE: adapted from encoding-down
   test(`chainedBatch.put() and del() take encoding options (deferred: ${deferred})`, async function (t) {
-    t.plan(deferred ? 2 : 4)
+    t.plan(deferred ? 2 : 5)
 
     let db
 
@@ -284,11 +287,14 @@ for (const deferred of [false, true]) {
           return mockChainedBatch(this, {
             _put: function (key, value, options) {
               t.same({ key, value }, { key: '"1"', value: '{"x":[2]}' })
-              t.same(options, { keyEncoding: 'utf8', valueEncoding: 'utf8' })
+
+              // May contain additional options just because it's cheaper to not remove them
+              t.is(options.keyEncoding, 'utf8')
+              t.is(options.valueEncoding, 'utf8')
             },
             _del: function (key, options) {
               t.is(key, '"3"')
-              t.same(options, { keyEncoding: 'utf8' })
+              t.is(options.keyEncoding, 'utf8')
             }
           })
         }

--- a/test/self/sublevel-test.js
+++ b/test/self/sublevel-test.js
@@ -58,6 +58,7 @@ test('sublevel is extensible', function (t) {
     open: true,
     closing: true,
     closed: true,
+    write: true,
     put: true,
     del: true,
     batch: true,

--- a/types/abstract-level.d.ts
+++ b/types/abstract-level.d.ts
@@ -220,9 +220,9 @@ declare class AbstractLevel<TFormat, KDefault = string, VDefault = string>
    * Create a sublevel.
    * @param name Name of the sublevel, used to prefix keys.
    */
-  sublevel (name: string): AbstractSublevel<typeof this, TFormat, string, string>
+  sublevel (name: string | string[]): AbstractSublevel<typeof this, TFormat, string, string>
   sublevel<K = string, V = string> (
-    name: string,
+    name: string | string[],
     options: AbstractSublevelOptions<K, V>
   ): AbstractSublevel<typeof this, TFormat, K, V>
 
@@ -234,10 +234,11 @@ declare class AbstractLevel<TFormat, KDefault = string, VDefault = string>
    * @param keyFormat Format of {@link key}. One of `'utf8'`, `'buffer'`, `'view'`.
    * If `'utf8'` then {@link key} must be a string and the return value will be a string.
    * If `'buffer'` then Buffer, if `'view'` then Uint8Array.
+   * @param local If true, add prefix for parent database, else for root database (default).
    */
-  prefixKey (key: string, keyFormat: 'utf8'): string
-  prefixKey (key: Buffer, keyFormat: 'buffer'): Buffer
-  prefixKey (key: Uint8Array, keyFormat: 'view'): Uint8Array
+  prefixKey (key: string, keyFormat: 'utf8', local?: boolean | undefined): string
+  prefixKey (key: Buffer, keyFormat: 'buffer', local?: boolean | undefined): Buffer
+  prefixKey (key: Uint8Array, keyFormat: 'view', local?: boolean | undefined): Uint8Array
 
   /**
    * Returns the given {@link encoding} argument as a normalized encoding object

--- a/types/abstract-level.d.ts
+++ b/types/abstract-level.d.ts
@@ -494,7 +494,10 @@ export interface AbstractClearOptions<K> extends RangeOptions<K> {
  *
  * @template TDatabase Type of database.
  */
-export interface AbstractDatabaseHooks<TDatabase, TOpenOptions = AbstractOpenOptions> {
+export interface AbstractDatabaseHooks<
+  TDatabase,
+  TOpenOptions = AbstractOpenOptions,
+  TBatchOperation = AbstractBatchOperation<TDatabase, any, any>> {
   /**
    * An asynchronous hook that runs after the database has succesfully opened, but before
    * deferred operations are executed and before events are emitted. Example:
@@ -516,9 +519,9 @@ export interface AbstractDatabaseHooks<TDatabase, TOpenOptions = AbstractOpenOpt
    * })
    * ```
    *
-   * @todo Define types of `op` and `batch`.
+   * @todo Define type of `op`.
    */
-  prewrite: AbstractHook<(op: any, batch: any) => void>
+  prewrite: AbstractHook<(op: any, batch: AbstractPrewriteBatch<TBatchOperation>) => void>
 
   /**
    * A synchronous hook that runs when an {@link AbstractSublevel} instance has been
@@ -528,6 +531,17 @@ export interface AbstractDatabaseHooks<TDatabase, TOpenOptions = AbstractOpenOpt
     sublevel: AbstractSublevel<TDatabase, any, any, any>,
     options: AbstractSublevelOptions<any, any>
   ) => void>
+}
+
+/**
+ * An interface for prewrite hook functions to add operations, to be committed in the
+ * same batch as the input operation(s).
+ */
+export interface AbstractPrewriteBatch<TBatchOperation> {
+  /**
+   * Add a batch operation.
+   */
+  add: (op: TBatchOperation) => this
 }
 
 /**

--- a/types/abstract-sublevel.d.ts
+++ b/types/abstract-sublevel.d.ts
@@ -29,7 +29,12 @@ declare class AbstractSublevel<TDatabase, TFormat, KDefault, VDefault>
   /**
    * Parent database. A read-only property.
    */
-  get db (): TDatabase
+  get parent (): TDatabase
+
+  /**
+   * Root database. A read-only property.
+   */
+  get db (): AbstractLevel<any, any, any>
 }
 
 /**


### PR DESCRIPTION
Adds postopen, prewrite and newsub hooks that allow userland "hook functions" to customize behavior of the database. See [README for details](https://github.com/Level/abstract-level/tree/hooks#hooks). A quick example:

```js
db.hooks.prewrite.add(function (op, batch) {
  if (op.type === 'put') {
    batch.add({
      type: 'put',
      key: op.value.foo,
      value: op.key,
      sublevel: fooIndex
    })
  }
})
```

More generally, this is a move towards "renewed modularity". Our ecosystem is old and many modules no longer work because they had no choice but to monkeypatch database methods, of which the signature has changed since then.

So in addition to hooks, this:

- [Introduces a new `write` event](https://github.com/Level/abstract-level/tree/hooks#events) that is emitted on `db.batch()`, `db.put()` and `db.del()` and has richer data: userland options, encoded data, keyEncoding and valueEncoding. The `batch`, `put` and `del` events are now deprecated and will be removed in a future version. Related to Level/level#222.
- Restores support of userland options on batch operations. In particular, to copy options in `db.batch(ops, options)` to ops, allowing for code like `db.batch(ops, { ttl: 123 })` to apply a default userland `ttl` option to all ops.

No breaking changes, yet. Using hooks means opting-in to new behaviors (like the new write event) and disables some old behaviors (like the deprecated events). Later on we can make those the default behavior, regardless of whether hooks are used.

TODO:

- [x] Benchmark
- [x] Write tests
- [x] Documentation for `batch` argument of prewrite hook function
- [x] Canary-test `memory-level`
- [x] Canary-test `classic-level`

Closes https://github.com/Level/community/issues/44.