### PR TITLE
Allow batches to write to a nondescendant sublevel

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ Perform multiple _put_ and/or _del_ operations in bulk. Returns a promise. The `
 
 Each operation must be an object with at least a `type` property set to either `'put'` or `'del'`. If the `type` is `'put'`, the operation must have `key` and `value` properties. It may optionally have `keyEncoding` and / or `valueEncoding` properties to encode keys or values with a custom encoding for just that operation. If the `type` is `'del'`, the operation must have a `key` property and may optionally have a `keyEncoding` property.
 
-An operation of either type may also have a `sublevel` property, to prefix the key of the operation with the prefix of that sublevel. This allows atomically committing data to multiple sublevels. The given `sublevel` must be a descendant of `db`. Keys and values will be encoded by the sublevel, to the same effect as a `sublevel.batch(..)` call. In the following example, the first `value` will be encoded with `'json'` rather than the default encoding of `db`:
+An operation of either type may also have a `sublevel` property, to prefix the key of the operation with the prefix of that sublevel. This allows atomically committing data to multiple sublevels. The given `sublevel` must have the same _root_ (i.e. top-most) database as `db`. Keys and values will be encoded by the sublevel, to the same effect as a `sublevel.batch(..)` call. In the following example, the first `value` will be encoded with `'json'` rather than the default encoding of `db`:
 
 ```js
 const people = db.sublevel('people', { valueEncoding: 'json' })
@@ -579,14 +579,14 @@ Add a `put` operation to this chained batch, not committed until `write()` is ca
 
 - `keyEncoding`: custom key encoding for this operation, used to encode the `key`.
 - `valueEncoding`: custom value encoding for this operation, used to encode the `value`.
-- `sublevel` (sublevel instance): act as though the `put` operation is performed on the given sublevel, to similar effect as `sublevel.batch().put(key, value)`. This allows atomically committing data to multiple sublevels. The given `sublevel` must be a descendant of `db`. The `key` will be prefixed with the prefix of the sublevel, and the `key` and `value` will be encoded by the sublevel (using the default encodings of the sublevel unless `keyEncoding` and / or `valueEncoding` are provided).
+- `sublevel` (sublevel instance): act as though the `put` operation is performed on the given sublevel, to similar effect as `sublevel.batch().put(key, value)`. This allows atomically committing data to multiple sublevels. The given `sublevel` must have the same _root_ (i.e. top-most) database as `chainedBatch.db`. The `key` will be prefixed with the prefix of the sublevel, and the `key` and `value` will be encoded by the sublevel (using the default encodings of the sublevel unless `keyEncoding` and / or `valueEncoding` are provided).
 
 #### `chainedBatch.del(key[, options])`
 
 Add a `del` operation to this chained batch, not committed until `write()` is called. This will throw a [`LEVEL_INVALID_KEY`](#errors) error if `key` is invalid. The optional `options` object may contain:
 
 - `keyEncoding`: custom key encoding for this operation, used to encode the `key`.
-- `sublevel` (sublevel instance): act as though the `del` operation is performed on the given sublevel, to similar effect as `sublevel.batch().del(key)`. This allows atomically committing data to multiple sublevels. The given `sublevel` must be a descendant of `db`. The `key` will be prefixed with the prefix of the sublevel, and the `key` will be encoded by the sublevel (using the default key encoding of the sublevel unless `keyEncoding` is provided).
+- `sublevel` (sublevel instance): act as though the `del` operation is performed on the given sublevel, to similar effect as `sublevel.batch().del(key)`. This allows atomically committing data to multiple sublevels. The given `sublevel` must have the same _root_ (i.e. top-most) database as `chainedBatch.db`. The `key` will be prefixed with the prefix of the sublevel, and the `key` will be encoded by the sublevel (using the default key encoding of the sublevel unless `keyEncoding` is provided).
 
 #### `chainedBatch.clear()`
 

--- a/lib/prefixes.js
+++ b/lib/prefixes.js
@@ -1,12 +1,21 @@
 'use strict'
 
 exports.prefixDescendantKey = function (key, keyFormat, descendant, ancestor) {
-  // TODO: optimize
-  // TODO: throw when ancestor is not descendant's ancestor?
   while (descendant !== null && descendant !== ancestor) {
     key = descendant.prefixKey(key, keyFormat, true)
     descendant = descendant.parent
   }
 
   return key
+}
+
+// Check if db is a descendant of ancestor
+// TODO: optimize, when used alongside prefixDescendantKey
+// which means we visit parents twice.
+exports.isDescendant = function (db, ancestor) {
+  while (true) {
+    if (db.parent == null) return false
+    if (db.parent === ancestor) return true
+    db = db.parent
+  }
 }

--- a/lib/prewrite-batch.js
+++ b/lib/prewrite-batch.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { prefixDescendantKey } = require('./prefixes')
+const { prefixDescendantKey, isDescendant } = require('./prefixes')
 
 const kDb = Symbol('db')
 const kPrivateOperations = Symbol('privateOperations')
@@ -40,14 +40,23 @@ class PrewriteBatch {
     const keyEncoding = op.keyEncoding
     const preencodedKey = keyEncoding.encode(op.key)
     const keyFormat = keyEncoding.format
-    const encodedKey = delegated ? prefixDescendantKey(preencodedKey, keyFormat, db, this[kDb]) : preencodedKey
 
-    // Prevent double prefixing
-    if (delegated) op.sublevel = null
+    // If the sublevel is not a descendant then forward that option to the parent db
+    // so that we don't erroneously add our own prefix to the key of the operation.
+    const siblings = delegated && !isDescendant(op.sublevel, this[kDb]) && op.sublevel !== this[kDb]
+    const encodedKey = delegated && !siblings
+      ? prefixDescendantKey(preencodedKey, keyFormat, db, this[kDb])
+      : preencodedKey
+
+    // Only prefix once
+    if (delegated && !siblings) {
+      op.sublevel = null
+    }
 
     let publicOperation = null
 
-    if (this[kPublicOperations] !== null) {
+    // If the sublevel is not a descendant then we shouldn't emit events
+    if (this[kPublicOperations] !== null && !siblings) {
       // Clone op before we mutate it for the private API
       publicOperation = Object.assign({}, op)
       publicOperation.encodedKey = encodedKey
@@ -61,7 +70,8 @@ class PrewriteBatch {
       this[kPublicOperations].push(publicOperation)
     }
 
-    op.key = this[kDb].prefixKey(encodedKey, keyFormat, true)
+    // If we're forwarding the sublevel option then don't prefix the key yet
+    op.key = siblings ? encodedKey : this[kDb].prefixKey(encodedKey, keyFormat, true)
     op.keyEncoding = keyFormat
 
     if (isPut) {


### PR DESCRIPTION
Closes #80. Follow-up for #45.