### PR TITLE
Implement explicit snapshots

### DIFF
--- a/abstract-snapshot.js
+++ b/abstract-snapshot.js
@@ -1,0 +1,78 @@
+'use strict'
+
+const ModuleError = require('module-error')
+const { noop } = require('./lib/common')
+
+class AbstractSnapshot {
+  #open = true
+  #referenceCount = 0
+  #pendingClose = null
+  #closePromise = null
+  #owner
+
+  constructor (options) {
+    // Defining this as an option gives sublevels the opportunity to create a snapshot
+    // via their parent database but still designate themselves as the "owner", which
+    // just means which database will close the snapshot upon db.close(). This ensures
+    // that the API of AbstractSublevel is symmetrical to AbstractLevel.
+    const owner = options.owner
+
+    if (typeof owner !== 'object' || owner === null) {
+      const hint = owner === null ? 'null' : typeof owner
+      throw new TypeError(`Owner must be an abstract-level database, received ${hint}`)
+    }
+
+    // Also ensures this db will not be garbage collected
+    this.#owner = owner
+    this.#owner.attachResource(this)
+  }
+
+  ref () {
+    if (!this.#open) {
+      throw new ModuleError('Snapshot is not open: cannot use snapshot after close()', {
+        code: 'LEVEL_SNAPSHOT_NOT_OPEN'
+      })
+    }
+
+    this.#referenceCount++
+  }
+
+  unref () {
+    if (--this.#referenceCount === 0 && this.#pendingClose !== null) {
+      this.#pendingClose()
+    }
+  }
+
+  async close () {
+    if (this.#closePromise !== null) {
+      // First caller of close() is responsible for error
+      return this.#closePromise.catch(noop)
+    }
+
+    this.#open = false
+
+    // Wrap to avoid race issues on recursive calls
+    this.#closePromise = new Promise((resolve, reject) => {
+      this.#pendingClose = () => {
+        this.#pendingClose = null
+        privateClose(this, this.#owner).then(resolve, reject)
+      }
+    })
+
+    // If working we'll delay closing, but still handle the close error (if any) here
+    if (this.#referenceCount === 0) {
+      this.#pendingClose()
+    }
+
+    return this.#closePromise
+  }
+
+  async _close () {}
+}
+
+const privateClose = async function (snapshot, owner) {
+  await snapshot._close()
+  owner.detachResource(snapshot)
+}
+
+exports.AbstractSnapshot = AbstractSnapshot

--- a/index.d.ts
+++ b/index.d.ts
@@ -38,4 +38,8 @@ export {
   AbstractSublevelOptions
 } from './types/abstract-sublevel'
 
+export {
+  AbstractSnapshot
+} from './types/abstract-snapshot'
+
 export * as Transcoder from 'level-transcoder'

--- a/index.js
+++ b/index.js
@@ -6,3 +6,4 @@ exports.AbstractIterator = require('./abstract-iterator').AbstractIterator
 exports.AbstractKeyIterator = require('./abstract-iterator').AbstractKeyIterator
 exports.AbstractValueIterator = require('./abstract-iterator').AbstractValueIterator
 exports.AbstractChainedBatch = require('./abstract-chained-batch').AbstractChainedBatch
+exports.AbstractSnapshot = require('./abstract-snapshot').AbstractSnapshot

--- a/lib/abstract-sublevel.js
+++ b/lib/abstract-sublevel.js
@@ -182,6 +182,10 @@ module.exports = function ({ AbstractLevel }) {
       const iterator = this[kRoot].values(options)
       return new AbstractSublevelValueIterator(this, options, iterator)
     }
+
+    _snapshot (options) {
+      return this[kRoot].snapshot(options)
+    }
   }
 
   return { AbstractSublevel }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "abstract-chained-batch.js",
     "abstract-iterator.js",
     "abstract-level.js",
+    "abstract-snapshot.js",
     "index.js",
     "index.d.ts",
     "lib",
@@ -27,7 +28,7 @@
   "dependencies": {
     "buffer": "^6.0.3",
     "is-buffer": "^2.0.5",
-    "level-supports": "^6.0.0",
+    "level-supports": "^6.1.1",
     "level-transcoder": "^1.0.1",
     "maybe-combine-errors": "^1.0.0",
     "module-error": "^1.0.1"

--- a/test/async-iterator-test.js
+++ b/test/async-iterator-test.js
@@ -53,7 +53,7 @@ exports.asyncIterator = function (test, testCommon) {
       await db.close()
     })
 
-    testCommon.supports.snapshots && test(`for await...of ${mode}() (deferred, with snapshot)`, async function (t) {
+    testCommon.supports.implicitSnapshots && test(`for await...of ${mode}() (deferred, with snapshot)`, async function (t) {
       t.plan(2)
 
       const db = testCommon.factory()

--- a/test/index.js
+++ b/test/index.js
@@ -43,10 +43,14 @@ function suite (options) {
     require('./iterator-seek-test').all(test, testCommon)
   }
 
-  if (testCommon.supports.snapshots) {
+  if (testCommon.supports.implicitSnapshots) {
     require('./iterator-snapshot-test').all(test, testCommon)
   } else {
     require('./iterator-no-snapshot-test').all(test, testCommon)
+  }
+
+  if (testCommon.supports.explicitSnapshots) {
+    require('./iterator-explicit-snapshot-test').all(test, testCommon)
   }
 
   require('./clear-test').all(test, testCommon)

--- a/test/iterator-explicit-snapshot-test.js
+++ b/test/iterator-explicit-snapshot-test.js
@@ -1,0 +1,356 @@
+'use strict'
+
+const traits = require('./traits')
+
+exports.traits = function (test, testCommon) {
+  // TODO: document (or fix...) that deferred open is not supported
+  traits.open('snapshot()', testCommon, { deferred: false }, async function (t, db) {
+    const snapshot = db.snapshot()
+    return snapshot.close()
+  })
+
+  traits.closed('snapshot()', testCommon, async function (t, db) {
+    db.snapshot()
+  })
+}
+
+exports.get = function (test, testCommon) {
+  const { testFresh, testClose } = testFactory(test, testCommon)
+
+  testFresh('get() changed entry from snapshot', async function (t, db) {
+    t.plan(3)
+
+    await db.put('abc', 'before')
+    const snapshot = db.snapshot()
+    await db.put('abc', 'after')
+
+    t.is(await db.get('abc'), 'after')
+    t.is(await db.get('abc', { snapshot }), 'before')
+    t.is(await db.get('other', { snapshot }), undefined)
+
+    return snapshot.close()
+  })
+
+  testFresh('get() deleted entry from snapshot', async function (t, db) {
+    t.plan(3)
+
+    await db.put('abc', 'before')
+    const snapshot = db.snapshot()
+    await db.del('abc')
+
+    t.is(await db.get('abc'), undefined)
+    t.is(await db.get('abc', { snapshot }), 'before')
+    t.is(await db.get('other', { snapshot }), undefined)
+
+    return snapshot.close()
+  })
+
+  testFresh('get() non-existent entry from snapshot', async function (t, db) {
+    t.plan(2)
+
+    const snapshot = db.snapshot()
+    await db.put('abc', 'after')
+
+    t.is(await db.get('abc'), 'after')
+    t.is(await db.get('abc', { snapshot }), undefined)
+
+    return snapshot.close()
+  })
+
+  testFresh('get() entries from multiple snapshots', async function (t, db) {
+    const snapshots = []
+    const iterations = 100
+
+    t.plan(iterations)
+
+    for (let i = 0; i < iterations; i++) {
+      await db.put('number', i.toString())
+      snapshots.push(db.snapshot())
+    }
+
+    for (let i = 0; i < iterations; i++) {
+      const snapshot = snapshots[i]
+      const value = i.toString()
+
+      t.is(await db.get('number', { snapshot }), value)
+    }
+
+    return Promise.all(snapshots.map(x => x.close()))
+  })
+
+  testFresh('get() entries from snapshot after closing another', async function (t, db) {
+    await db.put('abc', 'before')
+
+    const snapshot1 = db.snapshot()
+    const snapshot2 = db.snapshot()
+
+    await db.put('abc', 'after')
+    await snapshot1.close()
+
+    // Closing one snapshot should not affect the other
+    t.is(await db.get('abc', { snapshot: snapshot2 }), 'before')
+
+    return snapshot2.close()
+  })
+
+  testClose('get()', async function (db, snapshot) {
+    return db.get('xyz', { snapshot })
+  })
+}
+
+exports.getMany = function (test, testCommon) {
+  const { testFresh, testClose } = testFactory(test, testCommon)
+
+  testFresh('getMany() entries from snapshot', async function (t, db) {
+    t.plan(3)
+
+    await db.put('a', '1')
+    await db.put('b', '2')
+    await db.put('c', '3')
+
+    const snapshot = db.snapshot()
+
+    await db.put('a', 'abc')
+    await db.del('b')
+    await db.put('c', 'xyz')
+
+    t.same(await db.getMany(['a', 'b', 'c']), ['abc', undefined, 'xyz'])
+    t.same(await db.getMany(['a', 'b', 'c'], { snapshot }), ['1', '2', '3'])
+    t.same(await db.getMany(['a', 'b', 'c']), ['abc', undefined, 'xyz'], 'no side effects')
+
+    return snapshot.close()
+  })
+
+  testClose('getMany()', async function (db, snapshot) {
+    return db.getMany(['xyz'], { snapshot })
+  })
+}
+
+exports.iterator = function (test, testCommon) {
+  const { testFresh, testClose } = testFactory(test, testCommon)
+
+  testFresh('iterator(), keys(), values() with snapshot', async function (t, db) {
+    t.plan(10)
+
+    await db.put('a', '1')
+    await db.put('b', '2')
+    await db.put('c', '3')
+
+    const snapshot = db.snapshot()
+
+    await db.put('a', 'after')
+    await db.del('b')
+    await db.put('c', 'after')
+    await db.put('d', 'after')
+
+    t.same(
+      await db.iterator().all(),
+      [['a', 'after'], ['c', 'after'], ['d', 'after']],
+      'data was written'
+    )
+
+    for (const fn of [all, nextv, next]) {
+      t.same(await fn(db.iterator({ snapshot })), [['a', '1'], ['b', '2'], ['c', '3']], 'iterator')
+      t.same(await fn(db.keys({ snapshot })), ['a', 'b', 'c'], 'keys')
+      t.same(await fn(db.values({ snapshot })), ['1', '2', '3'], 'values')
+    }
+
+    async function all (iterator) {
+      return iterator.all()
+    }
+
+    async function nextv (iterator) {
+      try {
+        return iterator.nextv(10)
+      } finally {
+        await iterator.close()
+      }
+    }
+
+    async function next (iterator) {
+      try {
+        const entries = []
+        let entry
+
+        while ((entry = await iterator.next()) !== undefined) {
+          entries.push(entry)
+        }
+
+        return entries
+      } finally {
+        await iterator.close()
+      }
+    }
+
+    return snapshot.close()
+  })
+
+  // Test that every iterator type and read method checks snapshot state
+  for (const type of ['iterator', 'keys', 'values']) {
+    testClose(`${type}().all()`, async function (db, snapshot) {
+      return db[type]({ snapshot }).all()
+    })
+
+    testClose(`${type}().next()`, async function (db, snapshot) {
+      const iterator = db[type]({ snapshot })
+
+      try {
+        await iterator.next()
+      } finally {
+        iterator.close()
+      }
+    })
+
+    testClose(`${type}().nextv()`, async function (db, snapshot) {
+      const iterator = db[type]({ snapshot })
+
+      try {
+        await iterator.nextv(10)
+      } finally {
+        iterator.close()
+      }
+    })
+  }
+}
+
+exports.clear = function (test, testCommon) {
+  const { testFresh, testClose } = testFactory(test, testCommon)
+
+  testFresh('clear() entries from snapshot', async function (t, db) {
+    t.plan(2)
+
+    await db.put('a', 'xyz')
+    const snapshot = db.snapshot()
+
+    await db.put('b', 'xyz')
+    await db.clear({ snapshot })
+
+    t.same(await db.keys().all(), ['b'])
+    t.same(await db.keys({ snapshot }).all(), ['a'])
+
+    return snapshot.close()
+  })
+
+  testFresh('clear() entries from empty snapshot', async function (t, db) {
+    t.plan(2)
+
+    const snapshot = db.snapshot()
+
+    await db.put('a', 'xyz')
+    await db.clear({ snapshot })
+
+    t.same(await db.keys().all(), ['a'])
+    t.same(await db.keys({ snapshot }).all(), [])
+
+    return snapshot.close()
+  })
+
+  testClose('clear()', async function (db, snapshot) {
+    return db.clear({ snapshot })
+  })
+}
+
+exports.cleanup = function (test, testCommon) {
+  test('snapshot is closed on database close', async function (t) {
+    t.plan(1)
+
+    const db = testCommon.factory()
+    await db.open()
+    const snapshot = db.snapshot()
+    const promise = db.close()
+
+    try {
+      snapshot.ref()
+    } catch (err) {
+      t.is(err.code, 'LEVEL_SNAPSHOT_NOT_OPEN')
+    }
+
+    return promise
+  })
+
+  test('snapshot is closed along with iterator', async function (t) {
+    t.plan(2)
+
+    const db = testCommon.factory()
+    await db.open()
+    await db.put('beep', 'boop')
+
+    // These resources have a potentially tricky relationship. If all is well,
+    // db.close() calls both snapshot.close() and iterator.close() in parallel,
+    // and snapshot.close() and iterator.close() wait on the read. Crucially,
+    // closing the snapshot only waits for individual operations on the iterator
+    // rather than for the entire iterator to be closed (which may never happen).
+    const snapshot = db.snapshot()
+    const iterator = db.iterator({ snapshot })
+    const readPromise = iterator.all()
+    const closePromise = db.close()
+
+    try {
+      snapshot.ref()
+    } catch (err) {
+      t.is(err.code, 'LEVEL_SNAPSHOT_NOT_OPEN', 'snapshot is closing')
+    }
+
+    try {
+      await iterator.next()
+    } catch (err) {
+      // Effectively also asserts that the LEVEL_ITERATOR_NOT_OPEN error takes
+      // precedence over LEVEL_SNAPSHOT_NOT_OPEN.
+      t.is(err.code, 'LEVEL_ITERATOR_NOT_OPEN', 'iterator is closing')
+    }
+
+    return Promise.all([readPromise, closePromise])
+  })
+}
+
+exports.all = function (test, testCommon) {
+  exports.traits(test, testCommon)
+  exports.get(test, testCommon)
+  exports.getMany(test, testCommon)
+  exports.iterator(test, testCommon)
+  exports.clear(test, testCommon)
+  exports.cleanup(test, testCommon)
+}
+
+function testFactory (test, testCommon) {
+  const testFresh = function (name, run) {
+    test(name, async function (t) {
+      const db = testCommon.factory()
+      await db.open()
+      await run(t, db)
+      return db.close()
+    })
+  }
+
+  const testClose = function (name, run) {
+    testFresh(`${name} after closing snapshot`, async function (t, db) {
+      t.plan(1)
+
+      const snapshot = db.snapshot()
+      await snapshot.close()
+
+      try {
+        await run(db, snapshot)
+      } catch (err) {
+        t.is(err.code, 'LEVEL_SNAPSHOT_NOT_OPEN')
+      }
+    })
+
+    testFresh(`${name} while closing snapshot`, async function (t, db) {
+      t.plan(1)
+
+      const snapshot = db.snapshot()
+      const promise = snapshot.close()
+
+      try {
+        await run(db, snapshot)
+      } catch (err) {
+        t.is(err.code, 'LEVEL_SNAPSHOT_NOT_OPEN')
+      }
+
+      return promise
+    })
+  }
+
+  return { testFresh, testClose }
+}

--- a/test/iterator-seek-test.js
+++ b/test/iterator-seek-test.js
@@ -170,7 +170,7 @@ exports.seek = function (test, testCommon) {
       return db.close()
     })
 
-    if (testCommon.supports.snapshots) {
+    if (testCommon.supports.implicitSnapshots) {
       for (const reverse of [false, true]) {
         for (const deferred of [false, true]) {
           test(`${mode}().seek() respects snapshot (reverse: ${reverse}, deferred: ${deferred})`, async function (t) {

--- a/test/traits/closed.js
+++ b/test/traits/closed.js
@@ -18,7 +18,7 @@ module.exports = function (name, testCommon, run) {
         error = err
       }
 
-      t.is(error.code, 'LEVEL_DATABASE_NOT_OPEN')
+      t.is(error && error.code, 'LEVEL_DATABASE_NOT_OPEN')
     })
 
     test(`${name} on closing db fails (deferred open: ${deferred})`, async function (t) {
@@ -36,7 +36,7 @@ module.exports = function (name, testCommon, run) {
       }
 
       await promise
-      t.is(error.code, 'LEVEL_DATABASE_NOT_OPEN')
+      t.is(error && error.code, 'LEVEL_DATABASE_NOT_OPEN')
     })
   }
 }

--- a/test/traits/open.js
+++ b/test/traits/open.js
@@ -1,7 +1,13 @@
 'use strict'
 
-module.exports = function (name, testCommon, run) {
+module.exports = function (name, testCommon, options, run) {
+  if (typeof options === 'function') {
+    run = options
+    options = {}
+  }
+
   const test = testCommon.test
+  const deferred = options.deferred !== false
 
   test(`${name} on open db`, async function (t) {
     const db = testCommon.factory()
@@ -15,7 +21,7 @@ module.exports = function (name, testCommon, run) {
     return db.close()
   })
 
-  test(`${name} on opening db`, async function (t) {
+  deferred && test(`${name} on opening db`, async function (t) {
     const db = testCommon.factory()
     t.is(db.status, 'opening')
     await run(t, db)
@@ -38,7 +44,7 @@ module.exports = function (name, testCommon, run) {
     return db.close()
   })
 
-  test(`${name} on reopening db`, async function (t) {
+  deferred && test(`${name} on reopening db`, async function (t) {
     const db = testCommon.factory()
 
     await db.close()

--- a/types/abstract-level.d.ts
+++ b/types/abstract-level.d.ts
@@ -3,6 +3,7 @@ import * as Transcoder from 'level-transcoder'
 import { EventEmitter } from 'events'
 import { AbstractChainedBatch } from './abstract-chained-batch'
 import { AbstractSublevel, AbstractSublevelOptions } from './abstract-sublevel'
+import { AbstractSnapshot } from './abstract-snapshot'
 
 import {
   AbstractIterator,
@@ -234,6 +235,17 @@ declare class AbstractLevel<TFormat, KDefault = string, VDefault = string>
    * encoding interface.
    */
   valueEncoding (): Transcoder.Encoding<VDefault, TFormat, VDefault>
+
+  /**
+   * Create an explicit snapshot. Throws a `LEVEL_NOT_SUPPORTED` error if
+   * `db.supports.explicitSnapshots` is false.
+   *
+   * Don't forget to call `snapshot.close()` when done.
+   *
+   * @param options There are currently no options but specific implementations
+   * may add their own.
+   */
+  snapshot (options?: any | undefined): AbstractSnapshot
 
   /**
    * Call the function {@link fn} at a later time when {@link status} changes to

--- a/types/abstract-snapshot.d.ts
+++ b/types/abstract-snapshot.d.ts
@@ -1,0 +1,23 @@
+/**
+ * A lightweight token that represents a version of a database at a particular point in
+ * time.
+ */
+export class AbstractSnapshot {
+  /**
+   * Increment reference count, to register work that should delay closing until
+   * {@link unref} is called an equal amount of times. The promise that will be returned
+   * by {@link close} will not resolve until the reference count returns to 0. This
+   * prevents prematurely closing underlying resources while the snapshot is in use.
+   */
+  ref (): void
+
+  /**
+   * Decrement reference count, to indicate that the work has finished.
+   */
+  unref (): void
+
+  /**
+   * Close the snapshot.
+   */
+  close (): Promise<void>
+}


### PR DESCRIPTION
See https://github.com/Level/community/issues/118. TLDR:

```js
await db.put('example', 'before')
const snapshot = db.snapshot()
await db.put('example', 'after')
await db.get('example', { snapshot })) // Returns 'before'
await snapshot.close()
```