### PR TITLE
Breaking: use new language features

### DIFF
--- a/.airtap.yml
+++ b/.airtap.yml
@@ -12,3 +12,8 @@ presets:
       - airtap-electron
     browsers:
       - name: electron
+
+# Until airtap switches to rollup
+browserify:
+  - transform: babelify
+    presets: ["@babel/preset-env"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,12 @@ updates:
     ignore:
       - dependency-name: standard
       - dependency-name: ts-standard
-      - dependency-name: '@types/node'
+      - dependency-name: "@types/node"
       - dependency-name: voxpelli/tsconfig
       - dependency-name: typescript
       - dependency-name: hallmark
+      - dependency-name: "@babel/preset-env"
+      - dependency-name: babelify
 
       # Stay on the 3rd or 4th oldest stable release, per
       # https://www.electronjs.org/docs/latest/tutorial/electron-timelines#version-support-policy

--- a/abstract-chained-batch.js
+++ b/abstract-chained-batch.js
@@ -6,18 +6,20 @@ const { getOptions, emptyOptions, noop } = require('./lib/common')
 const { prefixDescendantKey, isDescendant } = require('./lib/prefixes')
 const { PrewriteBatch } = require('./lib/prewrite-batch')
 
-const kStatus = Symbol('status')
 const kPublicOperations = Symbol('publicOperations')
-const kLegacyOperations = Symbol('legacyOperations')
 const kPrivateOperations = Symbol('privateOperations')
-const kClosePromise = Symbol('closePromise')
-const kLength = Symbol('length')
-const kPrewriteRun = Symbol('prewriteRun')
-const kPrewriteBatch = Symbol('prewriteBatch')
-const kPrewriteData = Symbol('prewriteData')
-const kAddMode = Symbol('addMode')
 
 class AbstractChainedBatch {
+  #status = 'open'
+  #length = 0
+  #closePromise = null
+  #publicOperations
+  #legacyOperations
+  #prewriteRun
+  #prewriteBatch
+  #prewriteData
+  #addMode
+
   constructor (db, options) {
     if (typeof db !== 'object' || db === null) {
       const hint = db === null ? 'null' : typeof db
@@ -29,17 +31,14 @@ class AbstractChainedBatch {
 
     // Operations for write event. We can skip populating this array (and cloning of
     // operations, which is the expensive part) if there are 0 write event listeners.
-    this[kPublicOperations] = enableWriteEvent ? [] : null
+    this.#publicOperations = enableWriteEvent ? [] : null
 
     // Operations for legacy batch event. If user opted-in to write event or prewrite
     // hook, skip legacy batch event. We can't skip the batch event based on listener
     // count, because a listener may be added between put() or del() and write().
-    this[kLegacyOperations] = enableWriteEvent || enablePrewriteHook ? null : []
+    this.#legacyOperations = enableWriteEvent || enablePrewriteHook ? null : []
 
-    this[kLength] = 0
-    this[kStatus] = 'open'
-    this[kClosePromise] = null
-    this[kAddMode] = getOptions(options, emptyOptions).add === true
+    this.#addMode = getOptions(options, emptyOptions).add === true
 
     if (enablePrewriteHook) {
       // Use separate arrays to collect operations added by hook functions, because
@@ -47,13 +46,13 @@ class AbstractChainedBatch {
       // exists to separate internal data from the public PrewriteBatch interface.
       const data = new PrewriteData([], enableWriteEvent ? [] : null)
 
-      this[kPrewriteData] = data
-      this[kPrewriteBatch] = new PrewriteBatch(db, data[kPrivateOperations], data[kPublicOperations])
-      this[kPrewriteRun] = db.hooks.prewrite.run // TODO: document why
+      this.#prewriteData = data
+      this.#prewriteBatch = new PrewriteBatch(db, data[kPrivateOperations], data[kPublicOperations])
+      this.#prewriteRun = db.hooks.prewrite.run // TODO: document why
     } else {
-      this[kPrewriteData] = null
-      this[kPrewriteBatch] = null
-      this[kPrewriteRun] = null
+      this.#prewriteData = null
+      this.#prewriteBatch = null
+      this.#prewriteRun = null
     }
 
     this.db = db
@@ -61,15 +60,15 @@ class AbstractChainedBatch {
   }
 
   get length () {
-    if (this[kPrewriteData] !== null) {
-      return this[kLength] + this[kPrewriteData].length
+    if (this.#prewriteData !== null) {
+      return this.#length + this.#prewriteData.length
     } else {
-      return this[kLength]
+      return this.#length
     }
   }
 
   put (key, value, options) {
-    assertStatus(this)
+    this.#assertStatus()
     options = getOptions(options, emptyOptions)
 
     const delegated = options.sublevel != null
@@ -90,7 +89,7 @@ class AbstractChainedBatch {
       valueEncoding: db.valueEncoding(options.valueEncoding)
     })
 
-    if (this[kPrewriteRun] !== null) {
+    if (this.#prewriteRun !== null) {
       try {
         // Note: we could have chosen to recurse here so that prewriteBatch.put() would
         // call this.put(). But then operations added by hook functions would be inserted
@@ -99,7 +98,7 @@ class AbstractChainedBatch {
         // chained batch though, which is that it avoids blocking the event loop with
         // more than one operation at a time. On the other hand, if operations added by
         // hook functions are adjacent (i.e. sorted) committing them should be faster.
-        this[kPrewriteRun](op, this[kPrewriteBatch])
+        this.#prewriteRun(op, this.#prewriteBatch)
 
         // Normalize encodings again in case they were modified
         op.keyEncoding = db.keyEncoding(op.keyEncoding)
@@ -134,7 +133,7 @@ class AbstractChainedBatch {
     }
 
     // If the sublevel is not a descendant then we shouldn't emit events
-    if (this[kPublicOperations] !== null && !siblings) {
+    if (this.#publicOperations !== null && !siblings) {
       // Clone op before we mutate it for the private API
       const publicOperation = Object.assign({}, op)
       publicOperation.encodedKey = encodedKey
@@ -148,15 +147,15 @@ class AbstractChainedBatch {
         publicOperation.valueEncoding = this.db.valueEncoding(valueFormat)
       }
 
-      this[kPublicOperations].push(publicOperation)
-    } else if (this[kLegacyOperations] !== null && !siblings) {
+      this.#publicOperations.push(publicOperation)
+    } else if (this.#legacyOperations !== null && !siblings) {
       const legacyOperation = Object.assign({}, original)
 
       legacyOperation.type = 'put'
       legacyOperation.key = key
       legacyOperation.value = value
 
-      this[kLegacyOperations].push(legacyOperation)
+      this.#legacyOperations.push(legacyOperation)
     }
 
     // If we're forwarding the sublevel option then don't prefix the key yet
@@ -165,7 +164,7 @@ class AbstractChainedBatch {
     op.keyEncoding = keyFormat
     op.valueEncoding = valueFormat
 
-    if (this[kAddMode]) {
+    if (this.#addMode) {
       this._add(op)
     } else {
       // This "operation as options" trick avoids further cloning
@@ -173,14 +172,14 @@ class AbstractChainedBatch {
     }
 
     // Increment only on success
-    this[kLength]++
+    this.#length++
     return this
   }
 
   _put (key, value, options) {}
 
   del (key, options) {
-    assertStatus(this)
+    this.#assertStatus()
     options = getOptions(options, emptyOptions)
 
     const delegated = options.sublevel != null
@@ -197,9 +196,9 @@ class AbstractChainedBatch {
       keyEncoding: db.keyEncoding(options.keyEncoding)
     })
 
-    if (this[kPrewriteRun] !== null) {
+    if (this.#prewriteRun !== null) {
       try {
-        this[kPrewriteRun](op, this[kPrewriteBatch])
+        this.#prewriteRun(op, this.#prewriteBatch)
 
         // Normalize encoding again in case it was modified
         op.keyEncoding = db.keyEncoding(op.keyEncoding)
@@ -220,7 +219,7 @@ class AbstractChainedBatch {
     // Prevent double prefixing
     if (delegated) op.sublevel = null
 
-    if (this[kPublicOperations] !== null) {
+    if (this.#publicOperations !== null) {
       // Clone op before we mutate it for the private API
       const publicOperation = Object.assign({}, op)
       publicOperation.encodedKey = encodedKey
@@ -231,20 +230,20 @@ class AbstractChainedBatch {
         publicOperation.keyEncoding = this.db.keyEncoding(keyFormat)
       }
 
-      this[kPublicOperations].push(publicOperation)
-    } else if (this[kLegacyOperations] !== null) {
+      this.#publicOperations.push(publicOperation)
+    } else if (this.#legacyOperations !== null) {
       const legacyOperation = Object.assign({}, original)
 
       legacyOperation.type = 'del'
       legacyOperation.key = key
 
-      this[kLegacyOperations].push(legacyOperation)
+      this.#legacyOperations.push(legacyOperation)
     }
 
     op.key = this.db.prefixKey(encodedKey, keyFormat, true)
     op.keyEncoding = keyFormat
 
-    if (this[kAddMode]) {
+    if (this.#addMode) {
       this._add(op)
     } else {
       // This "operation as options" trick avoids further cloning
@@ -252,7 +251,7 @@ class AbstractChainedBatch {
     }
 
     // Increment only on success
-    this[kLength]++
+    this.#length++
     return this
   }
 
@@ -261,37 +260,37 @@ class AbstractChainedBatch {
   _add (op) {}
 
   clear () {
-    assertStatus(this)
+    this.#assertStatus()
     this._clear()
 
-    if (this[kPublicOperations] !== null) this[kPublicOperations] = []
-    if (this[kLegacyOperations] !== null) this[kLegacyOperations] = []
-    if (this[kPrewriteData] !== null) this[kPrewriteData].clear()
+    if (this.#publicOperations !== null) this.#publicOperations = []
+    if (this.#legacyOperations !== null) this.#legacyOperations = []
+    if (this.#prewriteData !== null) this.#prewriteData.clear()
 
-    this[kLength] = 0
+    this.#length = 0
     return this
   }
 
   _clear () {}
 
   async write (options) {
-    assertStatus(this)
+    this.#assertStatus()
     options = getOptions(options)
 
-    if (this[kLength] === 0) {
+    if (this.#length === 0) {
       return this.close()
     } else {
-      this[kStatus] = 'writing'
+      this.#status = 'writing'
 
       // Prepare promise in case close() is called in the mean time
-      const close = prepareClose(this)
+      const close = this.#prepareClose()
 
       try {
         // Process operations added by prewrite hook functions
-        if (this[kPrewriteData] !== null) {
-          const publicOperations = this[kPrewriteData][kPublicOperations]
-          const privateOperations = this[kPrewriteData][kPrivateOperations]
-          const length = this[kPrewriteData].length
+        if (this.#prewriteData !== null) {
+          const publicOperations = this.#prewriteData[kPublicOperations]
+          const privateOperations = this.#prewriteData[kPrivateOperations]
+          const length = this.#prewriteData.length
 
           for (let i = 0; i < length; i++) {
             const op = privateOperations[i]
@@ -300,7 +299,7 @@ class AbstractChainedBatch {
             // status isn't exposed to the private API, so there's no difference in state
             // from that perspective, unless an implementation overrides the public write()
             // method at its own risk.
-            if (this[kAddMode]) {
+            if (this.#addMode) {
               this._add(op)
             } else if (op.type === 'put') {
               this._put(op.key, op.value, op)
@@ -310,7 +309,7 @@ class AbstractChainedBatch {
           }
 
           if (publicOperations !== null && length !== 0) {
-            this[kPublicOperations] = this[kPublicOperations].concat(publicOperations)
+            this.#publicOperations = this.#publicOperations.concat(publicOperations)
           }
         }
 
@@ -319,7 +318,7 @@ class AbstractChainedBatch {
         close()
 
         try {
-          await this[kClosePromise]
+          await this.#closePromise
         } catch (closeErr) {
           // eslint-disable-next-line no-ex-assign
           err = combineErrors([err, closeErr])
@@ -332,54 +331,73 @@ class AbstractChainedBatch {
 
       // Emit after initiating the closing, because event may trigger a
       // db close which in turn triggers (idempotently) closing this batch.
-      if (this[kPublicOperations] !== null) {
-        this.db.emit('write', this[kPublicOperations])
-      } else if (this[kLegacyOperations] !== null) {
-        this.db.emit('batch', this[kLegacyOperations])
+      if (this.#publicOperations !== null) {
+        this.db.emit('write', this.#publicOperations)
+      } else if (this.#legacyOperations !== null) {
+        this.db.emit('batch', this.#legacyOperations)
       }
 
-      return this[kClosePromise]
+      return this.#closePromise
     }
   }
 
   async _write (options) {}
 
   async close () {
-    if (this[kClosePromise] !== null) {
+    if (this.#closePromise !== null) {
       // First caller of close() or write() is responsible for error
-      return this[kClosePromise].catch(noop)
+      return this.#closePromise.catch(noop)
     } else {
       // Wrap promise to avoid race issues on recursive calls
-      prepareClose(this)()
-      return this[kClosePromise]
+      this.#prepareClose()()
+      return this.#closePromise
     }
   }
 
   async _close () {}
+
+  #assertStatus () {
+    if (this.#status !== 'open') {
+      throw new ModuleError('Batch is not open: cannot change operations after write() or close()', {
+        code: 'LEVEL_BATCH_NOT_OPEN'
+      })
+    }
+
+    // Can technically be removed, because it's no longer possible to call db.batch() when
+    // status is not 'open', and db.close() closes the batch. Keep for now, in case of
+    // unforseen userland behaviors.
+    if (this.db.status !== 'open') {
+      /* istanbul ignore next */
+      throw new ModuleError('Database is not open', {
+        code: 'LEVEL_DATABASE_NOT_OPEN'
+      })
+    }
+  }
+
+  #prepareClose () {
+    let close
+
+    this.#closePromise = new Promise((resolve, reject) => {
+      close = () => {
+        this.#privateClose().then(resolve, reject)
+      }
+    })
+
+    return close
+  }
+
+  async #privateClose () {
+    // TODO: should we not set status earlier?
+    this.#status = 'closing'
+    await this._close()
+    this.db.detachResource(this)
+  }
 }
 
 if (typeof Symbol.asyncDispose === 'symbol') {
   AbstractChainedBatch.prototype[Symbol.asyncDispose] = async function () {
     return this.close()
   }
-}
-
-const prepareClose = function (batch) {
-  let close
-
-  batch[kClosePromise] = new Promise((resolve, reject) => {
-    close = () => {
-      privateClose(batch).then(resolve, reject)
-    }
-  })
-
-  return close
-}
-
-const privateClose = async function (batch) {
-  batch[kStatus] = 'closing'
-  await batch._close()
-  batch.db.detachResource(batch)
 }
 
 class PrewriteData {
@@ -402,24 +420,6 @@ class PrewriteData {
         ops.splice(0, ops.length)
       }
     }
-  }
-}
-
-const assertStatus = function (batch) {
-  if (batch[kStatus] !== 'open') {
-    throw new ModuleError('Batch is not open: cannot change operations after write() or close()', {
-      code: 'LEVEL_BATCH_NOT_OPEN'
-    })
-  }
-
-  // Can technically be removed, because it's no longer possible to call db.batch() when
-  // status is not 'open', and db.close() closes the batch. Keep for now, in case of
-  // unforseen userland behaviors.
-  if (batch.db.status !== 'open') {
-    /* istanbul ignore next */
-    throw new ModuleError('Database is not open', {
-      code: 'LEVEL_DATABASE_NOT_OPEN'
-    })
   }
 }
 

--- a/abstract-snapshot.js
+++ b/abstract-snapshot.js
@@ -38,8 +38,8 @@ class AbstractSnapshot {
   }
 
   unref () {
-    if (--this.#referenceCount === 0 && this.#pendingClose !== null) {
-      this.#pendingClose()
+    if (--this.#referenceCount === 0) {
+      this.#pendingClose?.()
     }
   }
 

--- a/lib/abstract-sublevel-iterator.js
+++ b/lib/abstract-sublevel-iterator.js
@@ -2,32 +2,32 @@
 
 const { AbstractIterator, AbstractKeyIterator, AbstractValueIterator } = require('../abstract-iterator')
 
-const kUnfix = Symbol('unfix')
-const kIterator = Symbol('iterator')
-
 // TODO: unfix natively if db supports it
 class AbstractSublevelIterator extends AbstractIterator {
+  #iterator
+  #unfix
+
   constructor (db, options, iterator, unfix) {
     super(db, options)
 
-    this[kIterator] = iterator
-    this[kUnfix] = unfix
+    this.#iterator = iterator
+    this.#unfix = unfix
   }
 
   async _next () {
-    const entry = await this[kIterator].next()
+    const entry = await this.#iterator.next()
 
     if (entry !== undefined) {
       const key = entry[0]
-      if (key !== undefined) entry[0] = this[kUnfix](key)
+      if (key !== undefined) entry[0] = this.#unfix(key)
     }
 
     return entry
   }
 
   async _nextv (size, options) {
-    const entries = await this[kIterator].nextv(size, options)
-    const unfix = this[kUnfix]
+    const entries = await this.#iterator.nextv(size, options)
+    const unfix = this.#unfix
 
     for (const entry of entries) {
       const key = entry[0]
@@ -38,8 +38,8 @@ class AbstractSublevelIterator extends AbstractIterator {
   }
 
   async _all (options) {
-    const entries = await this[kIterator].all(options)
-    const unfix = this[kUnfix]
+    const entries = await this.#iterator.all(options)
+    const unfix = this.#unfix
 
     for (const entry of entries) {
       const key = entry[0]
@@ -47,25 +47,36 @@ class AbstractSublevelIterator extends AbstractIterator {
     }
 
     return entries
+  }
+
+  _seek (target, options) {
+    this.#iterator.seek(target, options)
+  }
+
+  async _close () {
+    return this.#iterator.close()
   }
 }
 
 class AbstractSublevelKeyIterator extends AbstractKeyIterator {
+  #iterator
+  #unfix
+
   constructor (db, options, iterator, unfix) {
     super(db, options)
 
-    this[kIterator] = iterator
-    this[kUnfix] = unfix
+    this.#iterator = iterator
+    this.#unfix = unfix
   }
 
   async _next () {
-    const key = await this[kIterator].next()
-    return key === undefined ? key : this[kUnfix](key)
+    const key = await this.#iterator.next()
+    return key === undefined ? key : this.#unfix(key)
   }
 
   async _nextv (size, options) {
-    const keys = await this[kIterator].nextv(size, options)
-    const unfix = this[kUnfix]
+    const keys = await this.#iterator.nextv(size, options)
+    const unfix = this.#unfix
 
     for (let i = 0; i < keys.length; i++) {
       const key = keys[i]
@@ -76,8 +87,8 @@ class AbstractSublevelKeyIterator extends AbstractKeyIterator {
   }
 
   async _all (options) {
-    const keys = await this[kIterator].all(options)
-    const unfix = this[kUnfix]
+    const keys = await this.#iterator.all(options)
+    const unfix = this.#unfix
 
     for (let i = 0; i < keys.length; i++) {
       const key = keys[i]
@@ -85,35 +96,43 @@ class AbstractSublevelKeyIterator extends AbstractKeyIterator {
     }
 
     return keys
+  }
+
+  _seek (target, options) {
+    this.#iterator.seek(target, options)
+  }
+
+  async _close () {
+    return this.#iterator.close()
   }
 }
 
 class AbstractSublevelValueIterator extends AbstractValueIterator {
+  #iterator
+
   constructor (db, options, iterator) {
     super(db, options)
-    this[kIterator] = iterator
+    this.#iterator = iterator
   }
 
   async _next () {
-    return this[kIterator].next()
+    return this.#iterator.next()
   }
 
   async _nextv (size, options) {
-    return this[kIterator].nextv(size, options)
+    return this.#iterator.nextv(size, options)
   }
 
   async _all (options) {
-    return this[kIterator].all(options)
-  }
-}
-
-for (const Iterator of [AbstractSublevelIterator, AbstractSublevelKeyIterator, AbstractSublevelValueIterator]) {
-  Iterator.prototype._seek = function (target, options) {
-    this[kIterator].seek(target, options)
+    return this.#iterator.all(options)
   }
 
-  Iterator.prototype._close = async function () {
-    return this[kIterator].close()
+  _seek (target, options) {
+    this.#iterator.seek(target, options)
+  }
+
+  async _close () {
+    return this.#iterator.close()
   }
 }
 

--- a/lib/abstract-sublevel.js
+++ b/lib/abstract-sublevel.js
@@ -8,22 +8,21 @@ const {
   AbstractSublevelValueIterator
 } = require('./abstract-sublevel-iterator')
 
-const kGlobalPrefix = Symbol('prefix')
-const kLocalPrefix = Symbol('localPrefix')
-const kLocalPath = Symbol('localPath')
-const kGlobalPath = Symbol('globalPath')
-const kGlobalUpperBound = Symbol('upperBound')
-const kPrefixRange = Symbol('prefixRange')
 const kRoot = Symbol('root')
-const kParent = Symbol('parent')
-const kUnfix = Symbol('unfix')
-
 const textEncoder = new TextEncoder()
 const defaults = { separator: '!' }
 
 // Wrapped to avoid circular dependency
 module.exports = function ({ AbstractLevel }) {
   class AbstractSublevel extends AbstractLevel {
+    #globalPrefix
+    #localPrefix
+    #localPath
+    #globalPath
+    #globalUpperBound
+    #parent
+    #unfix
+
     static defaults (options) {
       if (options == null) {
         return defaults
@@ -62,17 +61,17 @@ module.exports = function ({ AbstractLevel }) {
       // still forward to the root database - which is older logic and does not yet need
       // to change, until we add some form of preread or postread hooks.
       this[kRoot] = root
-      this[kParent] = db
-      this[kLocalPath] = names
-      this[kGlobalPath] = db.prefix ? db.path().concat(names) : names
-      this[kGlobalPrefix] = new MultiFormat(globalPrefix)
-      this[kGlobalUpperBound] = new MultiFormat(globalUpperBound)
-      this[kLocalPrefix] = new MultiFormat(localPrefix)
-      this[kUnfix] = new Unfixer()
+      this.#parent = db
+      this.#localPath = names
+      this.#globalPath = db.prefix ? db.path().concat(names) : names
+      this.#globalPrefix = new MultiFormat(globalPrefix)
+      this.#globalUpperBound = new MultiFormat(globalUpperBound)
+      this.#localPrefix = new MultiFormat(localPrefix)
+      this.#unfix = new Unfixer()
     }
 
     prefixKey (key, keyFormat, local) {
-      const prefix = local ? this[kLocalPrefix] : this[kGlobalPrefix]
+      const prefix = local ? this.#localPrefix : this.#globalPrefix
 
       if (keyFormat === 'utf8') {
         return prefix.utf8 + key
@@ -94,13 +93,13 @@ module.exports = function ({ AbstractLevel }) {
     }
 
     // Not exposed for now.
-    [kPrefixRange] (range, keyFormat) {
+    #prefixRange (range, keyFormat) {
       if (range.gte !== undefined) {
         range.gte = this.prefixKey(range.gte, keyFormat, false)
       } else if (range.gt !== undefined) {
         range.gt = this.prefixKey(range.gt, keyFormat, false)
       } else {
-        range.gte = this[kGlobalPrefix][keyFormat]
+        range.gte = this.#globalPrefix[keyFormat]
       }
 
       if (range.lte !== undefined) {
@@ -108,12 +107,12 @@ module.exports = function ({ AbstractLevel }) {
       } else if (range.lt !== undefined) {
         range.lt = this.prefixKey(range.lt, keyFormat, false)
       } else {
-        range.lte = this[kGlobalUpperBound][keyFormat]
+        range.lte = this.#globalUpperBound[keyFormat]
       }
     }
 
     get prefix () {
-      return this[kGlobalPrefix].utf8
+      return this.#globalPrefix.utf8
     }
 
     get db () {
@@ -121,72 +120,72 @@ module.exports = function ({ AbstractLevel }) {
     }
 
     get parent () {
-      return this[kParent]
+      return this.#parent
     }
 
     path (local = false) {
-      return local ? this[kLocalPath] : this[kGlobalPath]
+      return local ? this.#localPath : this.#globalPath
     }
 
     async _open (options) {
       // The parent db must open itself or be (re)opened by the user because
       // a sublevel should not initiate state changes on the rest of the db.
-      return this[kParent].open({ passive: true })
+      return this.#parent.open({ passive: true })
     }
 
     async _put (key, value, options) {
-      return this[kParent].put(key, value, options)
+      return this.#parent.put(key, value, options)
     }
 
     async _get (key, options) {
-      return this[kParent].get(key, options)
+      return this.#parent.get(key, options)
     }
 
     async _getMany (keys, options) {
-      return this[kParent].getMany(keys, options)
+      return this.#parent.getMany(keys, options)
     }
 
     async _has (key, options) {
-      return this[kParent].has(key, options)
+      return this.#parent.has(key, options)
     }
 
     async _hasMany (keys, options) {
-      return this[kParent].hasMany(keys, options)
+      return this.#parent.hasMany(keys, options)
     }
 
     async _del (key, options) {
-      return this[kParent].del(key, options)
+      return this.#parent.del(key, options)
     }
 
     async _batch (operations, options) {
-      return this[kParent].batch(operations, options)
+      return this.#parent.batch(operations, options)
     }
 
     // TODO: call parent instead of root
     async _clear (options) {
       // TODO (refactor): move to AbstractLevel
-      this[kPrefixRange](options, options.keyEncoding)
+      this.#prefixRange(options, options.keyEncoding)
       return this[kRoot].clear(options)
     }
 
     // TODO: call parent instead of root
     _iterator (options) {
       // TODO (refactor): move to AbstractLevel
-      this[kPrefixRange](options, options.keyEncoding)
+      this.#prefixRange(options, options.keyEncoding)
       const iterator = this[kRoot].iterator(options)
-      const unfix = this[kUnfix].get(this[kGlobalPrefix].utf8.length, options.keyEncoding)
+      const unfix = this.#unfix.get(this.#globalPrefix.utf8.length, options.keyEncoding)
       return new AbstractSublevelIterator(this, options, iterator, unfix)
     }
 
     _keys (options) {
-      this[kPrefixRange](options, options.keyEncoding)
+      this.#prefixRange(options, options.keyEncoding)
       const iterator = this[kRoot].keys(options)
-      const unfix = this[kUnfix].get(this[kGlobalPrefix].utf8.length, options.keyEncoding)
+      const unfix = this.#unfix.get(this.#globalPrefix.utf8.length, options.keyEncoding)
       return new AbstractSublevelKeyIterator(this, options, iterator, unfix)
     }
 
     _values (options) {
-      this[kPrefixRange](options, options.keyEncoding)
+      this.#prefixRange(options, options.keyEncoding)
       const iterator = this[kRoot].values(options)
       return new AbstractSublevelValueIterator(this, options, iterator)
     }

--- a/lib/default-chained-batch.js
+++ b/lib/default-chained-batch.js
@@ -1,28 +1,28 @@
 'use strict'
 
 const { AbstractChainedBatch } = require('../abstract-chained-batch')
-const kEncoded = Symbol('encoded')
 
 // Functional default for chained batch
 class DefaultChainedBatch extends AbstractChainedBatch {
+  #encoded = []
+
   constructor (db) {
     // Opt-in to _add() instead of _put() and _del()
     super(db, { add: true })
-    this[kEncoded] = []
   }
 
   _add (op) {
-    this[kEncoded].push(op)
+    this.#encoded.push(op)
   }
 
   _clear () {
-    this[kEncoded] = []
+    this.#encoded = []
   }
 
   async _write (options) {
     // Need to call the private rather than public method, to prevent
     // recursion, double prefixing, double encoding and double hooks.
-    return this.db._batch(this[kEncoded], options)
+    return this.db._batch(this.#encoded, options)
   }
 }
 

--- a/lib/deferred-queue.js
+++ b/lib/deferred-queue.js
@@ -3,10 +3,6 @@
 const { getOptions, emptyOptions } = require('./common')
 const { AbortError } = require('./errors')
 
-const kOperations = Symbol('operations')
-const kSignals = Symbol('signals')
-const kHandleAbort = Symbol('handleAbort')
-
 class DeferredOperation {
   constructor (fn, signal) {
     this.fn = fn
@@ -15,10 +11,12 @@ class DeferredOperation {
 }
 
 class DeferredQueue {
+  #operations
+  #signals
+
   constructor () {
-    this[kOperations] = []
-    this[kSignals] = new Set()
-    this[kHandleAbort] = this[kHandleAbort].bind(this)
+    this.#operations = []
+    this.#signals = new Set()
   }
 
   add (fn, options) {
@@ -26,7 +24,7 @@ class DeferredQueue {
     const signal = options.signal
 
     if (signal == null) {
-      this[kOperations].push(new DeferredOperation(fn, null))
+      this.#operations.push(new DeferredOperation(fn, null))
       return
     }
 
@@ -36,23 +34,23 @@ class DeferredQueue {
       return
     }
 
-    if (!this[kSignals].has(signal)) {
-      this[kSignals].add(signal)
-      signal.addEventListener('abort', this[kHandleAbort], { once: true })
+    if (!this.#signals.has(signal)) {
+      this.#signals.add(signal)
+      signal.addEventListener('abort', this.#handleAbort, { once: true })
     }
 
-    this[kOperations].push(new DeferredOperation(fn, signal))
+    this.#operations.push(new DeferredOperation(fn, signal))
   }
 
   drain () {
-    const operations = this[kOperations]
-    const signals = this[kSignals]
+    const operations = this.#operations
+    const signals = this.#signals
 
-    this[kOperations] = []
-    this[kSignals] = new Set()
+    this.#operations = []
+    this.#signals = new Set()
 
     for (const signal of signals) {
-      signal.removeEventListener('abort', this[kHandleAbort])
+      signal.removeEventListener('abort', this.#handleAbort)
     }
 
     for (const operation of operations) {
@@ -60,13 +58,13 @@ class DeferredQueue {
     }
   }
 
-  [kHandleAbort] (ev) {
+  #handleAbort = (ev) => {
     const signal = ev.target
     const err = new AbortError()
     const aborted = []
 
     // TODO: optimize
-    this[kOperations] = this[kOperations].filter(function (operation) {
+    this.#operations = this.#operations.filter(function (operation) {
       if (operation.signal !== null && operation.signal === signal) {
         aborted.push(operation)
         return false
@@ -75,7 +73,7 @@ class DeferredQueue {
       }
     })
 
-    this[kSignals].delete(signal)
+    this.#signals.delete(signal)
 
     for (const operation of aborted) {
       operation.fn.call(null, err)

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -2,9 +2,6 @@
 
 const { noop } = require('./common')
 
-const kFunctions = Symbol('functions')
-const kAsync = Symbol('async')
-
 class DatabaseHooks {
   constructor () {
     this.postopen = new Hook({ async: true })
@@ -14,30 +11,60 @@ class DatabaseHooks {
 }
 
 class Hook {
+  #functions = new Set()
+  #isAsync
+
   constructor (options) {
-    this[kAsync] = options.async
-    this[kFunctions] = new Set()
+    this.#isAsync = options.async
 
     // Offer a fast way to check if hook functions are present. We could also expose a
     // size getter, which would be slower, or check it by hook.run !== noop, which would
     // not allow userland to do the same check.
     this.noop = true
-    this.run = runner(this)
+    this.run = this.#runner()
   }
 
   add (fn) {
     // Validate now rather than in asynchronous code paths
     assertFunction(fn)
-    this[kFunctions].add(fn)
+    this.#functions.add(fn)
     this.noop = false
-    this.run = runner(this)
+    this.run = this.#runner()
   }
 
   delete (fn) {
     assertFunction(fn)
-    this[kFunctions].delete(fn)
-    this.noop = this[kFunctions].size === 0
-    this.run = runner(this)
+    this.#functions.delete(fn)
+    this.noop = this.#functions.size === 0
+    this.run = this.#runner()
+  }
+
+  #runner () {
+    if (this.noop) {
+      return noop
+    } else if (this.#functions.size === 1) {
+      const [fn] = this.#functions
+      return fn
+    } else if (this.#isAsync) {
+      // The run function should not reference hook, so that consumers like chained batch
+      // and db.open() can save a reference to hook.run and safely assume it won't change
+      // during their lifetime or async work.
+      const run = async function (functions, ...args) {
+        for (const fn of functions) {
+          await fn(...args)
+        }
+      }
+
+      return run.bind(null, Array.from(this.#functions))
+    } else {
+      const run = function (functions, ...args) {
+        for (const fn of functions) {
+          fn(...args)
+        }
+      }
+
+      return run.bind(null, Array.from(this.#functions))
+    }
   }
 }
 
@@ -45,34 +72,6 @@ const assertFunction = function (fn) {
   if (typeof fn !== 'function') {
     const hint = fn === null ? 'null' : typeof fn
     throw new TypeError(`The first argument must be a function, received ${hint}`)
-  }
-}
-
-const runner = function (hook) {
-  if (hook.noop) {
-    return noop
-  } else if (hook[kFunctions].size === 1) {
-    const [fn] = hook[kFunctions]
-    return fn
-  } else if (hook[kAsync]) {
-    // The run function should not reference hook, so that consumers like chained batch
-    // and db.open() can save a reference to hook.run and safely assume it won't change
-    // during their lifetime or async work.
-    const run = async function (functions, ...args) {
-      for (const fn of functions) {
-        await fn(...args)
-      }
-    }
-
-    return run.bind(null, Array.from(hook[kFunctions]))
-  } else {
-    const run = function (functions, ...args) {
-      for (const fn of functions) {
-        fn(...args)
-      }
-    }
-
-    return run.bind(null, Array.from(hook[kFunctions]))
   }
 }
 

--- a/lib/prewrite-batch.js
+++ b/lib/prewrite-batch.js
@@ -2,25 +2,25 @@
 
 const { prefixDescendantKey, isDescendant } = require('./prefixes')
 
-const kDb = Symbol('db')
-const kPrivateOperations = Symbol('privateOperations')
-const kPublicOperations = Symbol('publicOperations')
-
 // An interface for prewrite hook functions to add operations
 class PrewriteBatch {
+  #db
+  #privateOperations
+  #publicOperations
+
   constructor (db, privateOperations, publicOperations) {
-    this[kDb] = db
+    this.#db = db
 
     // Note: if for db.batch([]), these arrays include input operations (or empty slots
     // for them) but if for chained batch then it does not. Small implementation detail.
-    this[kPrivateOperations] = privateOperations
-    this[kPublicOperations] = publicOperations
+    this.#privateOperations = privateOperations
+    this.#publicOperations = publicOperations
   }
 
   add (op) {
     const isPut = op.type === 'put'
     const delegated = op.sublevel != null
-    const db = delegated ? op.sublevel : this[kDb]
+    const db = delegated ? op.sublevel : this.#db
 
     const keyError = db._checkKey(op.key)
     if (keyError != null) throw keyError
@@ -43,9 +43,9 @@ class PrewriteBatch {
 
     // If the sublevel is not a descendant then forward that option to the parent db
     // so that we don't erroneously add our own prefix to the key of the operation.
-    const siblings = delegated && !isDescendant(op.sublevel, this[kDb]) && op.sublevel !== this[kDb]
+    const siblings = delegated && !isDescendant(op.sublevel, this.#db) && op.sublevel !== this.#db
     const encodedKey = delegated && !siblings
-      ? prefixDescendantKey(preencodedKey, keyFormat, db, this[kDb])
+      ? prefixDescendantKey(preencodedKey, keyFormat, db, this.#db)
       : preencodedKey
 
     // Only prefix once
@@ -56,22 +56,22 @@ class PrewriteBatch {
     let publicOperation = null
 
     // If the sublevel is not a descendant then we shouldn't emit events
-    if (this[kPublicOperations] !== null && !siblings) {
+    if (this.#publicOperations !== null && !siblings) {
       // Clone op before we mutate it for the private API
       publicOperation = Object.assign({}, op)
       publicOperation.encodedKey = encodedKey
 
       if (delegated) {
-        // Ensure emitted data makes sense in the context of this[kDb]
+        // Ensure emitted data makes sense in the context of this.#db
         publicOperation.key = encodedKey
-        publicOperation.keyEncoding = this[kDb].keyEncoding(keyFormat)
+        publicOperation.keyEncoding = this.#db.keyEncoding(keyFormat)
       }
 
-      this[kPublicOperations].push(publicOperation)
+      this.#publicOperations.push(publicOperation)
     }
 
     // If we're forwarding the sublevel option then don't prefix the key yet
-    op.key = siblings ? encodedKey : this[kDb].prefixKey(encodedKey, keyFormat, true)
+    op.key = siblings ? encodedKey : this.#db.prefixKey(encodedKey, keyFormat, true)
     op.keyEncoding = keyFormat
 
     if (isPut) {
@@ -87,12 +87,12 @@ class PrewriteBatch {
 
         if (delegated) {
           publicOperation.value = encodedValue
-          publicOperation.valueEncoding = this[kDb].valueEncoding(valueFormat)
+          publicOperation.valueEncoding = this.#db.valueEncoding(valueFormat)
         }
       }
     }
 
-    this[kPrivateOperations].push(op)
+    this.#privateOperations.push(op)
     return this
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,11 +34,13 @@
     "module-error": "^1.0.1"
   },
   "devDependencies": {
+    "@babel/preset-env": "^7.26.0",
     "@types/node": "^22.7.7",
     "@voxpelli/tsconfig": "^15.0.0",
     "airtap": "^4.0.4",
     "airtap-electron": "^1.0.0",
     "airtap-playwright": "^1.0.1",
+    "babelify": "^10.0.0",
     "electron": "^30.5.1",
     "hallmark": "^5.0.1",
     "nyc": "^15.1.0",


### PR DESCRIPTION
Namely private properties, optional chaining and the nullish coalescing operator. This is a syntactic refactoring that makes no difference for most consumers. The syntax is supported by all our target environments, but if browserify is used (without babel or similar) it'll fail to parse.