### PR TITLE
Implement `has()` and `hasMany()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,45 @@ Get multiple values from the database by an array of `keys`. The optional `optio
 
 Returns a promise for an array of values with the same order as `keys`. If a key was not found, the relevant value will be `undefined`.
 
+### `db.has(key[, options])`
+
+Check if the database has an entry with the given `key`. The optional `options` object may contain:
+
+- `keyEncoding`: custom key encoding for this operation, used to encode the `key`.
+- `snapshot`: explicit [snapshot](#snapshot--dbsnapshotoptions) to read from. If no `snapshot` is provided and `db.supports.implicitSnapshots` is true, the database will create its own internal snapshot for this operation.
+
+Returns a promise for a boolean. For example:
+
+```js
+if (await db.has('fruit')) {
+  console.log('We have fruit')
+}
+```
+
+If the value of the entry is needed, instead do:
+
+```js
+const value = await db.get('fruit')
+
+if (value !== undefined) {
+  console.log('We have fruit: %o', value)
+}
+```
+
+### `db.hasMany(keys[, options])`
+
+Check if the database has entries with the given keys. The `keys` argument must be an array. The optional `options` object may contain:
+
+- `keyEncoding`: custom key encoding for this operation, used to encode the `keys`.
+- `snapshot`: explicit [snapshot](#snapshot--dbsnapshotoptions) to read from. If no `snapshot` is provided and `db.supports.implicitSnapshots` is true, the database will create its own internal snapshot for this operation.
+
+Returns a promise for an array of booleans with the same order as `keys`. For example:
+
+```js
+await db.put('a', '123')
+await db.hasMany(['a', 'b']) // [true, false]
+```
+
 ### `db.put(key, value[, options])`
 
 Add a new entry or overwrite an existing entry. The optional `options` object may contain:

--- a/lib/abstract-sublevel.js
+++ b/lib/abstract-sublevel.js
@@ -146,6 +146,14 @@ module.exports = function ({ AbstractLevel }) {
       return this[kParent].getMany(keys, options)
     }
 
+    async _has (key, options) {
+      return this[kParent].has(key, options)
+    }
+
+    async _hasMany (keys, options) {
+      return this[kParent].hasMany(keys, options)
+    }
+
     async _del (key, options) {
       return this[kParent].del(key, options)
     }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "buffer": "^6.0.3",
     "is-buffer": "^2.0.5",
-    "level-supports": "^6.1.1",
+    "level-supports": "^6.2.0",
     "level-transcoder": "^1.0.1",
     "maybe-combine-errors": "^1.0.0",
     "module-error": "^1.0.1"

--- a/test/has-many-test.js
+++ b/test/has-many-test.js
@@ -1,0 +1,144 @@
+'use strict'
+
+const { illegalKeys } = require('./util')
+const traits = require('./traits')
+
+let db
+
+/**
+ * @param {import('tape')} test
+ */
+exports.setUp = function (test, testCommon) {
+  test('hasMany() setup', async function (t) {
+    db = testCommon.factory()
+    return db.open()
+  })
+}
+
+/**
+ * @param {import('tape')} test
+ */
+exports.args = function (test, testCommon) {
+  test('hasMany() requires an array argument', function (t) {
+    t.plan(6)
+
+    db.hasMany().catch(function (err) {
+      t.is(err && err.name, 'TypeError')
+      t.is(err && err.message, "The first argument 'keys' must be an array")
+    })
+
+    db.hasMany('foo').catch(function (err) {
+      t.is(err && err.name, 'TypeError')
+      t.is(err && err.message, "The first argument 'keys' must be an array")
+    })
+
+    db.hasMany('foo', {}).catch(function (err) {
+      t.is(err && err.name, 'TypeError')
+      t.is(err && err.message, "The first argument 'keys' must be an array")
+    })
+  })
+
+  test('hasMany() with illegal keys', function (t) {
+    t.plan(illegalKeys.length * 4)
+
+    for (const { name, key } of illegalKeys) {
+      db.hasMany([key]).catch(function (err) {
+        t.ok(err instanceof Error, name + ' - is Error')
+        t.is(err.code, 'LEVEL_INVALID_KEY', name + ' - correct error code')
+      })
+
+      db.hasMany(['valid', key]).catch(function (err) {
+        t.ok(err instanceof Error, name + ' - is Error (second key)')
+        t.is(err.code, 'LEVEL_INVALID_KEY', name + ' - correct error code (second key)')
+      })
+    }
+  })
+}
+
+/**
+ * @param {import('tape')} test
+ */
+exports.hasMany = function (test, testCommon) {
+  test('simple hasMany()', async function (t) {
+    await db.put('foo', 'bar')
+
+    t.same(await db.hasMany(['foo']), [true])
+    t.same(await db.hasMany(['foo'], {}), [true]) // same but with {}
+    t.same(await db.hasMany(['beep']), [false])
+
+    await db.put('beep', 'boop')
+
+    t.same(await db.hasMany(['beep']), [true])
+    t.same(await db.hasMany(['foo', 'beep']), [true, true])
+    t.same(await db.hasMany(['aaa', 'beep']), [false, true])
+    t.same(await db.hasMany(['beep', 'aaa']), [true, false], 'maintains order of input keys')
+  })
+
+  test('empty hasMany()', async function (t) {
+    t.same(await db.hasMany([]), [])
+
+    const encodings = Object.keys(db.supports.encodings)
+      .filter(k => db.supports.encodings[k])
+
+    for (const valueEncoding of encodings) {
+      t.same(await db.hasMany([], { valueEncoding }), [])
+    }
+  })
+
+  test('simultaneous hasMany()', async function (t) {
+    t.plan(20)
+
+    await db.put('hello', 'world')
+    const promises = []
+
+    for (let i = 0; i < 10; ++i) {
+      promises.push(db.hasMany(['hello']).then(function (values) {
+        t.same(values, [true])
+      }))
+    }
+
+    for (let i = 0; i < 10; ++i) {
+      promises.push(db.hasMany(['non-existent']).then(function (values) {
+        t.same(values, [false])
+      }))
+    }
+
+    return Promise.all(promises)
+  })
+
+  traits.open('hasMany()', testCommon, async function (t, db) {
+    t.same(await db.hasMany(['foo']), [false])
+  })
+
+  traits.closed('hasMany()', testCommon, async function (t, db) {
+    return db.hasMany(['foo'])
+  })
+
+  // Also test empty array because it has a fast-path
+  traits.open('hasMany() with empty array', testCommon, async function (t, db) {
+    t.same(await db.hasMany([]), [])
+  })
+
+  traits.closed('hasMany() with empty array', testCommon, async function (t, db) {
+    return db.hasMany([])
+  })
+}
+
+/**
+ * @param {import('tape')} test
+ */
+exports.tearDown = function (test, testCommon) {
+  test('hasMany() teardown', async function (t) {
+    return db.close()
+  })
+}
+
+/**
+ * @param {import('tape')} test
+ */
+exports.all = function (test, testCommon) {
+  exports.setUp(test, testCommon)
+  exports.args(test, testCommon)
+  exports.hasMany(test, testCommon)
+  exports.tearDown(test, testCommon)
+}

--- a/test/has-test.js
+++ b/test/has-test.js
@@ -1,0 +1,81 @@
+'use strict'
+
+const { illegalKeys } = require('./util')
+const traits = require('./traits')
+
+let db
+
+exports.setUp = function (test, testCommon) {
+  test('has() setup', async function (t) {
+    db = testCommon.factory()
+    return db.open()
+  })
+}
+
+exports.args = function (test, testCommon) {
+  test('has() with illegal keys', function (t) {
+    t.plan(illegalKeys.length * 2)
+
+    for (const { name, key } of illegalKeys) {
+      db.has(key).catch(function (err) {
+        t.ok(err instanceof Error, name + ' - is Error')
+        t.is(err.code, 'LEVEL_INVALID_KEY', name + ' - correct error code')
+      })
+    }
+  })
+}
+
+exports.has = function (test, testCommon) {
+  test('simple has()', async function (t) {
+    await db.put('foo', 'bar')
+
+    t.is(await db.has('foo'), true)
+    t.is(await db.has('foo', {}), true) // same but with {}
+
+    for (const key of ['non-existent', Math.random()]) {
+      t.is(await db.has(key), false, 'not found')
+    }
+  })
+
+  test('simultaneous has()', async function (t) {
+    t.plan(20)
+
+    await db.put('hello', 'world')
+    const promises = []
+
+    for (let i = 0; i < 10; ++i) {
+      promises.push(db.has('hello').then((value) => {
+        t.is(value, true, 'found')
+      }))
+    }
+
+    for (let i = 0; i < 10; ++i) {
+      promises.push(db.has('non-existent').then((value) => {
+        t.is(value, false, 'not found')
+      }))
+    }
+
+    return Promise.all(promises)
+  })
+
+  traits.open('has()', testCommon, async function (t, db) {
+    t.is(await db.has('foo'), false)
+  })
+
+  traits.closed('has()', testCommon, async function (t, db) {
+    return db.has('foo')
+  })
+}
+
+exports.tearDown = function (test, testCommon) {
+  test('has() teardown', async function (t) {
+    return db.close()
+  })
+}
+
+exports.all = function (test, testCommon) {
+  exports.setUp(test, testCommon)
+  exports.args(test, testCommon)
+  exports.has(test, testCommon)
+  exports.tearDown(test, testCommon)
+}

--- a/test/index.js
+++ b/test/index.js
@@ -25,6 +25,11 @@ function suite (options) {
   require('./put-get-del-test').all(test, testCommon)
   require('./get-many-test').all(test, testCommon)
 
+  if (testCommon.supports.has) {
+    require('./has-test').all(test, testCommon)
+    require('./has-many-test').all(test, testCommon)
+  }
+
   require('./batch-test').all(test, testCommon)
   require('./chained-batch-test').all(test, testCommon)
 

--- a/test/util.js
+++ b/test/util.js
@@ -91,6 +91,7 @@ class MinimalLevel extends AbstractLevel {
     super({
       encodings: { utf8: true },
       seek: true,
+      has: true,
       explicitSnapshots: true
     }, options)
 
@@ -111,6 +112,16 @@ class MinimalLevel extends AbstractLevel {
   async _getMany (keys, options) {
     const entries = (options.snapshot || this)[kEntries]
     return keys.map(k => entries.get(k))
+  }
+
+  async _has (key, options) {
+    const entries = (options.snapshot || this)[kEntries]
+    return entries.has(key)
+  }
+
+  async _hasMany (keys, options) {
+    const entries = (options.snapshot || this)[kEntries]
+    return keys.map(k => entries.has(k))
   }
 
   async _del (key, options) {

--- a/types/abstract-level.d.ts
+++ b/types/abstract-level.d.ts
@@ -95,6 +95,35 @@ declare class AbstractLevel<TFormat, KDefault = string, VDefault = string>
   ): Promise<(V | undefined)[]>
 
   /**
+   * Check if the database has an entry with the given {@link key}.
+   *
+   * @returns A promise for a boolean that will be true if the entry exists.
+   *
+   * @example
+   * ```js
+   * if (await db.has('fruit')) {
+   *   console.log('We have fruit')
+   * }
+   * ```
+   */
+  has (key: KDefault): Promise<boolean>
+  has<K = KDefault> (key: K, options: AbstractHasOptions<K>): Promise<boolean>
+
+  /**
+   * Check if the database has entries with the given {@link keys}.
+   *
+   * @returns A promise for an array of booleans with the same order as {@link keys}.
+   *
+   * @example
+   * ```js
+   * await db.put('a', '123')
+   * await db.hasMany(['a', 'b']) // [true, false]
+   * ```
+   */
+  hasMany (keys: KDefault[]): Promise<boolean[]>
+  hasMany<K = KDefault> (keys: K[], options: AbstractHasManyOptions<K>): Promise<boolean[]>
+
+  /**
    * Add a new entry or overwrite an existing entry.
    */
   put (key: KDefault, value: VDefault): Promise<void>
@@ -347,6 +376,26 @@ export interface AbstractGetManyOptions<K, V> {
    * Custom value encoding for this operation, used to decode values.
    */
   valueEncoding?: string | Transcoder.PartialDecoder<V> | undefined
+}
+
+/**
+ * Options for the {@link AbstractLevel.has} method.
+ */
+export interface AbstractHasOptions<K> {
+  /**
+   * Custom key encoding for this operation, used to encode the `key`.
+   */
+  keyEncoding?: string | Transcoder.PartialEncoder<K> | undefined
+}
+
+/**
+ * Options for the {@link AbstractLevel.hasMany} method.
+ */
+export interface AbstractHasManyOptions<K> {
+  /**
+   * Custom key encoding for this operation, used to encode the `keys`.
+   */
+  keyEncoding?: string | Transcoder.PartialEncoder<K> | undefined
 }
 
 /**


### PR DESCRIPTION
Adds two methods:

```js
await db.put('love', 'u')
await db.has('love') // true
await db.hasMany(['love', 'hate']) // [true, false]
```

Ref: https://github.com/Level/community/issues/142