### PR TITLE
Breaking: remove deprecated `put`, `del` & `batch` events

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,8 +848,6 @@ Lastly, one way or another, every implementation _must_ support `data` of type S
 
 An `abstract-level` database is an [`EventEmitter`](https://nodejs.org/api/events.html) and emits the events listed below.
 
-The `put`, `del` and `batch` events are deprecated in favor of the `write` event and will be removed in a future version of `abstract-level`. If one or more `write` event listeners exist or if the [`prewrite`](#hook--dbhooksprewrite) hook is in use, either of which implies opting-in to the `write` event, then the deprecated events will not be emitted.
-
 #### `opening`
 
 Emitted when database is opening. Receives 0 arguments:
@@ -966,42 +964,6 @@ The same is true for `db.put()` and `db.del()`.
 #### `clear`
 
 Emitted when a `db.clear()` call completed and entries were thus successfully deleted from the database. Receives a single `options` argument, which is the verbatim `options` argument that was passed to `db.clear(options)` (or an empty object if none) before having encoded range options.
-
-#### `put` (deprecated)
-
-Emitted when a `db.put()` call completed and an entry was thus successfully written to the database. Receives `key` and `value` arguments, which are the verbatim `key` and `value` that were passed to `db.put(key, value)` before having encoded them.
-
-```js
-db.on('put', function (key, value) {
-  console.log('Wrote', key, value)
-})
-```
-
-#### `del` (deprecated)
-
-Emitted when a `db.del()` call completed and an entry was thus successfully deleted from the database. Receives a single `key` argument, which is the verbatim `key` that was passed to `db.del(key)` before having encoded it.
-
-```js
-db.on('del', function (key) {
-  console.log('Deleted', key)
-})
-```
-
-#### `batch` (deprecated)
-
-Emitted when a `db.batch([])` or chained `db.batch().write()` call completed and the data was thus successfully written to the database. Receives a single `operations` argument, which is the verbatim `operations` array that was passed to `db.batch(operations)` before having encoded it, or the equivalent for a chained `db.batch().write()`.
-
-```js
-db.on('batch', function (operations) {
-  for (const op of operations) {
-    if (op.type === 'put') {
-      console.log('Wrote', op.key, op.value)
-    } else {
-      console.log('Deleted', op.key)
-    }
-  }
-})
-```
 
 ### Order Of Operations
 

--- a/abstract-level.js
+++ b/abstract-level.js
@@ -65,21 +65,11 @@ class AbstractLevel extends EventEmitter {
         closing: true,
         closed: true,
         write: true,
-        put: true,
-        del: true,
-        batch: true,
         clear: true
       }
     })
 
-    // Monitor event listeners
-    this.#eventMonitor = new EventMonitor(this, [
-      { name: 'write' },
-      { name: 'put', deprecated: true, alt: 'write' },
-      { name: 'del', deprecated: true, alt: 'write' },
-      { name: 'batch', deprecated: true, alt: 'write' }
-    ])
-
+    this.#eventMonitor = new EventMonitor(this, [{ name: 'write' }])
     this.#transcoder = new Transcoder(formats(this))
     this.#keyEncoding = this.#transcoder.encoding(keyEncoding || 'utf8')
     this.#valueEncoding = this.#transcoder.encoding(valueEncoding || 'utf8')
@@ -579,9 +569,6 @@ class AbstractLevel extends EventEmitter {
       }
 
       this.emit('write', [op])
-    } else {
-      // TODO (semver-major): remove
-      this.emit('put', key, value)
     }
   }
 
@@ -630,9 +617,6 @@ class AbstractLevel extends EventEmitter {
       }
 
       this.emit('write', [op])
-    } else {
-      // TODO (semver-major): remove
-      this.emit('del', key)
     }
   }
 
@@ -783,9 +767,6 @@ class AbstractLevel extends EventEmitter {
 
     if (enableWriteEvent) {
       this.emit('write', publicOperations)
-    } else if (!enablePrewriteHook) {
-      // TODO (semver-major): remove
-      this.emit('batch', operations)
     }
   }
 

--- a/abstract-level.js
+++ b/abstract-level.js
@@ -69,7 +69,7 @@ class AbstractLevel extends EventEmitter {
       }
     })
 
-    this.#eventMonitor = new EventMonitor(this, [{ name: 'write' }])
+    this.#eventMonitor = new EventMonitor(this)
     this.#transcoder = new Transcoder(formats(this))
     this.#keyEncoding = this.#transcoder.encoding(keyEncoding || 'utf8')
     this.#valueEncoding = this.#transcoder.encoding(valueEncoding || 'utf8')

--- a/lib/event-monitor.js
+++ b/lib/event-monitor.js
@@ -7,11 +7,6 @@ exports.EventMonitor = class EventMonitor {
     for (const event of events) {
       // Track whether listeners are present
       this[event.name] = false
-
-      // Prepare deprecation message
-      if (event.deprecated) {
-        event.message = `The '${event.name}' event is deprecated in favor of '${event.alt}' and will be removed in a future version of abstract-level`
-      }
     }
 
     const map = new Map(events.map(e => [e.name, e]))
@@ -26,8 +21,8 @@ exports.EventMonitor = class EventMonitor {
       if (event !== undefined) {
         monitor[name] = true
 
-        if (event.deprecated) {
-          deprecate(event.message)
+        if (name === 'put' || name === 'del' || name === 'batch') {
+          deprecate(`The '${name}' event has been removed in favor of 'write'`)
         }
       }
     }

--- a/lib/event-monitor.js
+++ b/lib/event-monitor.js
@@ -3,34 +3,28 @@
 const { deprecate } = require('./common')
 
 exports.EventMonitor = class EventMonitor {
-  constructor (emitter, events) {
-    for (const event of events) {
-      // Track whether listeners are present
-      this[event.name] = false
+  constructor (emitter) {
+    // Track whether listeners are present, because checking
+    // a boolean is faster than checking listenerCount().
+    this.write = false
+
+    const beforeAdded = (name) => {
+      if (name === 'write') {
+        this.write = true
+      }
+
+      if (name === 'put' || name === 'del' || name === 'batch') {
+        deprecate(`The '${name}' event has been removed in favor of 'write'`)
+      }
     }
 
-    const map = new Map(events.map(e => [e.name, e]))
-    const monitor = this
+    const afterRemoved = (name) => {
+      if (name === 'write') {
+        this.write = emitter.listenerCount('write') > 0
+      }
+    }
 
     emitter.on('newListener', beforeAdded)
     emitter.on('removeListener', afterRemoved)
-
-    function beforeAdded (name) {
-      const event = map.get(name)
-
-      if (event !== undefined) {
-        monitor[name] = true
-
-        if (name === 'put' || name === 'del' || name === 'batch') {
-          deprecate(`The '${name}' event has been removed in favor of 'write'`)
-        }
-      }
-    }
-
-    function afterRemoved (name) {
-      if (map.has(name)) {
-        monitor[name] = this.listenerCount(name) > 0
-      }
-    }
   }
 }

--- a/test/batch-test.js
+++ b/test/batch-test.js
@@ -199,24 +199,6 @@ exports.atomic = function (test, testCommon) {
   })
 }
 
-exports.events = function (test, testCommon) {
-  test('batch([]) emits batch event', async function (t) {
-    t.plan(2)
-
-    const db = testCommon.factory()
-    await db.open()
-
-    t.ok(db.supports.events.batch)
-
-    db.on('batch', function (ops) {
-      t.same(ops, [{ type: 'put', key: 456, value: 99, custom: 123 }])
-    })
-
-    await db.batch([{ type: 'put', key: 456, value: 99, custom: 123 }])
-    return db.close()
-  })
-}
-
 exports.tearDown = function (test, testCommon) {
   test('batch([]) teardown', async function (t) {
     return db.close()
@@ -228,6 +210,5 @@ exports.all = function (test, testCommon) {
   exports.args(test, testCommon)
   exports.batch(test, testCommon)
   exports.atomic(test, testCommon)
-  exports.events(test, testCommon)
   exports.tearDown(test, testCommon)
 }

--- a/test/del-test.js
+++ b/test/del-test.js
@@ -41,31 +41,13 @@ exports.del = function (test, testCommon) {
 
   traits.open('del()', testCommon, async function (t, db) {
     let emitted = false
-    db.once('del', () => { emitted = true })
-    t.is(await assertPromise(db.del('foo')), undefined, 'void promise')
-    t.ok(emitted)
+    db.once('write', () => { emitted = true })
+    t.is(await db.del('foo'), undefined, 'void promise')
+    t.ok(emitted) // Not sure what the purpose of this test is
   })
 
   traits.closed('del()', testCommon, async function (t, db) {
     return db.del('foo')
-  })
-}
-
-exports.events = function (test, testCommon) {
-  test('del() emits del event', async function (t) {
-    t.plan(2)
-
-    const db = testCommon.factory()
-    await db.open()
-
-    t.ok(db.supports.events.del)
-
-    db.on('del', function (key) {
-      t.is(key, 456)
-    })
-
-    await db.del(456)
-    return db.close()
   })
 }
 
@@ -79,6 +61,5 @@ exports.all = function (test, testCommon) {
   exports.setUp(test, testCommon)
   exports.args(test, testCommon)
   exports.del(test, testCommon)
-  exports.events(test, testCommon)
   exports.tearDown(test, testCommon)
 }

--- a/test/put-test.js
+++ b/test/put-test.js
@@ -56,20 +56,6 @@ exports.put = function (test, testCommon) {
   })
 }
 
-exports.events = function (test, testCommon) {
-  test('put() emits put event', async function (t) {
-    t.plan(3)
-    t.ok(db.supports.events.put)
-
-    db.on('put', function (key, value) {
-      t.is(key, 123)
-      t.is(value, 'b')
-    })
-
-    await db.put(123, 'b')
-  })
-}
-
 exports.tearDown = function (test, testCommon) {
   test('put() teardown', async function (t) {
     return db.close()
@@ -80,6 +66,5 @@ exports.all = function (test, testCommon) {
   exports.setUp(test, testCommon)
   exports.args(test, testCommon)
   exports.put(test, testCommon)
-  exports.events(test, testCommon)
   exports.tearDown(test, testCommon)
 }

--- a/test/self/sublevel-test.js
+++ b/test/self/sublevel-test.js
@@ -58,9 +58,6 @@ test('sublevel is extensible', function (t) {
     closing: true,
     closed: true,
     write: true,
-    put: true,
-    del: true,
-    batch: true,
     clear: true
   })
 


### PR DESCRIPTION
In favor of the `write` event.

While still printing a warning if listeners are added for these events, because it's cheap and helps people who are upgrading.