### PR TITLE
Breaking: change `_checkKey` and `_checkValue` to assertions

### DIFF
--- a/abstract-chained-batch.js
+++ b/abstract-chained-batch.js
@@ -74,11 +74,9 @@ class AbstractChainedBatch {
     const delegated = options.sublevel != null
     const db = delegated ? options.sublevel : this.db
     const original = options
-    const keyError = db._checkKey(key)
-    const valueError = db._checkValue(value)
 
-    if (keyError != null) throw keyError
-    if (valueError != null) throw valueError
+    db._assertValidKey(key)
+    db._assertValidValue(value)
 
     // Avoid spread operator because of https://bugs.chromium.org/p/chromium/issues/detail?id=1204540
     const op = Object.assign({}, options, {
@@ -185,9 +183,8 @@ class AbstractChainedBatch {
     const delegated = options.sublevel != null
     const db = delegated ? options.sublevel : this.db
     const original = options
-    const keyError = db._checkKey(key)
 
-    if (keyError != null) throw keyError
+    db._assertValidKey(key)
 
     // Avoid spread operator because of https://bugs.chromium.org/p/chromium/issues/detail?id=1204540
     const op = Object.assign({}, options, {

--- a/abstract-level.js
+++ b/abstract-level.js
@@ -320,9 +320,7 @@ class AbstractLevel extends EventEmitter {
     }
 
     this.#assertOpen()
-
-    const err = this._checkKey(key)
-    if (err) throw err
+    this._assertValidKey(key)
 
     const snapshot = options.snapshot
     const keyEncoding = this.keyEncoding(options.keyEncoding)
@@ -397,9 +395,7 @@ class AbstractLevel extends EventEmitter {
 
     for (let i = 0; i < keys.length; i++) {
       const key = keys[i]
-      const err = this._checkKey(key)
-      if (err) throw err
-
+      this._assertValidKey(key)
       mappedKeys[i] = this.prefixKey(keyEncoding.encode(key), keyFormat, true)
     }
 
@@ -443,10 +439,7 @@ class AbstractLevel extends EventEmitter {
     }
 
     this.#assertOpen()
-
-    // TODO (next major): change this to an assert
-    const err = this._checkKey(key)
-    if (err) throw err
+    this._assertValidKey(key)
 
     const snapshot = options.snapshot
     const keyEncoding = this.keyEncoding(options.keyEncoding)
@@ -515,9 +508,7 @@ class AbstractLevel extends EventEmitter {
 
     for (let i = 0; i < keys.length; i++) {
       const key = keys[i]
-      const err = this._checkKey(key)
-      if (err) throw err
-
+      this._assertValidKey(key)
       mappedKeys[i] = this.prefixKey(keyEncoding.encode(key), keyFormat, true)
     }
 
@@ -554,8 +545,8 @@ class AbstractLevel extends EventEmitter {
 
     this.#assertOpen()
 
-    const err = this._checkKey(key) || this._checkValue(value)
-    if (err) throw err
+    this._assertValidKey(key)
+    this._assertValidValue(value)
 
     // Encode data for private API
     const keyEncoding = this.keyEncoding(options.keyEncoding)
@@ -612,9 +603,7 @@ class AbstractLevel extends EventEmitter {
     }
 
     this.#assertOpen()
-
-    const err = this._checkKey(key)
-    if (err) throw err
+    this._assertValidKey(key)
 
     // Encode data for private API
     const keyEncoding = this.keyEncoding(options.keyEncoding)
@@ -701,15 +690,12 @@ class AbstractLevel extends EventEmitter {
       const delegated = op.sublevel != null
       const db = delegated ? op.sublevel : this
 
-      const keyError = db._checkKey(op.key)
-      if (keyError != null) throw keyError
+      db._assertValidKey(op.key)
 
       op.keyEncoding = db.keyEncoding(op.keyEncoding)
 
       if (isPut) {
-        const valueError = db._checkValue(op.value)
-        if (valueError != null) throw valueError
-
+        db._assertValidValue(op.value)
         op.valueEncoding = db.valueEncoding(op.valueEncoding)
       } else if (op.type !== 'del') {
         throw new TypeError("A batch operation must have a type property that is 'put' or 'del'")
@@ -1008,17 +994,17 @@ class AbstractLevel extends EventEmitter {
     return new DefaultChainedBatch(this)
   }
 
-  _checkKey (key) {
+  _assertValidKey (key) {
     if (key === null || key === undefined) {
-      return new ModuleError('Key cannot be null or undefined', {
+      throw new ModuleError('Key cannot be null or undefined', {
         code: 'LEVEL_INVALID_KEY'
       })
     }
   }
 
-  _checkValue (value) {
+  _assertValidValue (value) {
     if (value === null || value === undefined) {
-      return new ModuleError('Value cannot be null or undefined', {
+      throw new ModuleError('Value cannot be null or undefined', {
         code: 'LEVEL_INVALID_VALUE'
       })
     }

--- a/lib/prewrite-batch.js
+++ b/lib/prewrite-batch.js
@@ -22,15 +22,11 @@ class PrewriteBatch {
     const delegated = op.sublevel != null
     const db = delegated ? op.sublevel : this.#db
 
-    const keyError = db._checkKey(op.key)
-    if (keyError != null) throw keyError
-
+    db._assertValidKey(op.key)
     op.keyEncoding = db.keyEncoding(op.keyEncoding)
 
     if (isPut) {
-      const valueError = db._checkValue(op.value)
-      if (valueError != null) throw valueError
-
+      db._assertValidValue(op.value)
       op.valueEncoding = db.valueEncoding(op.valueEncoding)
     } else if (op.type !== 'del') {
       throw new TypeError("A batch operation must have a type property that is 'put' or 'del'")


### PR DESCRIPTION
Only matters for implementations that override these methods, and not for end users.